### PR TITLE
Band-aid fix for missing titles on saved games

### DIFF
--- a/BannerKings/BannerKingsCheats.cs
+++ b/BannerKings/BannerKingsCheats.cs
@@ -45,5 +45,13 @@ namespace BannerKings
 
 			return "Knighthood requirements for player companions enabled.";
 		}
+
+		[CommandLineFunctionality.CommandLineArgumentFunction("reinit_titles", "bannerkings")]
+		public static string ReinitTitles(List<string> strings)
+		{
+			BannerKingsConfig.Instance.TitleManager.InitializeTitles();
+
+			return "Successfully reinitted titles.";
+		}
 	}
 }


### PR DESCRIPTION
I know this is a very band-aid (and simple) solution to an existing problem, but I was able to get titles which were broken on my 500 day save, working with this single console command I've added. I have played a few days and nothing seemed out of ordinary, I think this should solve the demesne overview crashes and the missing titles for the time being, also keep up the good work with the mod.