### PR TITLE
Fixes arithmetic for Magnum Opus inside BKLearningModel.CalculateLearningRate

### DIFF
--- a/BannerKings/Models/Vanilla/BKLearningModel.cs
+++ b/BannerKings/Models/Vanilla/BKLearningModel.cs
@@ -95,7 +95,7 @@ namespace BannerKings.Models.Vanilla
 
             if (hero.GetPerkValue(BKPerks.Instance.ScholarshipMagnumOpus))
             {
-                result.Add(0.02f * hero.GetSkillValue(BKSkills.Instance.Scholarship) - 230, BKPerks.Instance.ScholarshipMagnumOpus.Name);
+                result.Add(0.02f * (hero.GetSkillValue(BKSkills.Instance.Scholarship) - 230), BKPerks.Instance.ScholarshipMagnumOpus.Name);
             }
 
             result.LimitMin(0.05f);


### PR DESCRIPTION
Adds parens so that the difference between current skill value and 230 is calculated before multiplying it with the factor.

Without the parens, the value will be calculated as such:

1. 0.02 * skillValue
2. then subtracting 230

instead of the, what I suppose is, the intended

1. skillValue - 230
2. then multiplying with 0.02