### PR TITLE
Reset Party Supply Demand setting added

### DIFF
--- a/BannerKings/Behaviours/PartyNeeds/PartySupplies.cs
+++ b/BannerKings/Behaviours/PartyNeeds/PartySupplies.cs
@@ -4,6 +4,7 @@ using BannerKings.Managers.Items;
 using BannerKings.Managers.Titles;
 using BannerKings.Managers.Titles.Laws;
 using BannerKings.Models.BKModels;
+using BannerKings.Settings;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
@@ -156,6 +157,19 @@ namespace BannerKings.Behaviours.PartyNeeds
 
         public void Tick()
         {
+            if (BannerKingsSettings.Instance.ResetPartySupplyDemand)
+            {
+                AlcoholNeed = 0f;
+                WoodNeed = 0f;
+                ToolsNeed = 0f;
+                ClothNeed = 0f;
+                ArrowsNeed = 0f;
+                WeaponsNeed = 0f;
+                HorsesNeed = 0f;
+                AnimalProductsNeed = 0f;
+                ShieldsNeed = 0f;
+            }
+
             if (Party.MemberRoster.Count > MinimumSoldiersThreshold)
             {
                 IPartyNeedsModel model = BannerKingsConfig.Instance.PartyNeedsModel;

--- a/BannerKings/Settings/BannerKingsSettings.cs
+++ b/BannerKings/Settings/BannerKingsSettings.cs
@@ -89,6 +89,10 @@ namespace BannerKings.Settings
         [SettingPropertyGroup("{=P8UecnYf}Balancing")]
         public float PartySuppliesFactor { get; set; } = 1f;
 
+        [SettingProperty("{=iBLGdG1Y}Reset Party Supplies Demand", RequireRestart = false, HintText = "{=uURHROGF}Party supply demands stack each day. Enabling this setting forgets the old demands of the party.")]
+        [SettingPropertyGroup("{=P8UecnYf}Balancing")]
+        public bool ResetPartySupplyDemand { get; set; } = false;
+
         [SettingPropertyInteger("{=iLmmsgFE}Volunteers Limit", 6, 20, "{=Bm4KO72P}0 Volunteers",
             Order = 1, RequireRestart = false, HintText = "{=2AsFpOok}The number of volunteers that notables may have. Requires reloading. Vanilla is 6, default for BK is 10. The recruitable amount is calculated on percentages and thus is always balanced. Recruits will be lost when changing to a smaller limit. Limits can be changed at any point during campaigns.")]
         [SettingPropertyGroup("{=P8UecnYf}Balancing")]


### PR DESCRIPTION
#144 Changing Party Supply later in game maintains the supply demand of all earlier ticks/days. The added setting can be enabled to reset old demands before calculating the party needs.