### PR TITLE
Fix Custom settlements start game crash

### DIFF
--- a/BannerKings/Behaviours/BKReligionsBehavior.cs
+++ b/BannerKings/Behaviours/BKReligionsBehavior.cs
@@ -175,6 +175,11 @@ namespace BannerKings.Behaviours
             Hero capturerHero,
             ChangeOwnerOfSettlementAction.ChangeOwnerOfSettlementDetail detail)
         {
+            if (capturerHero == null)
+            {
+                return;
+            }
+            
             if (BannerKingsConfig.Instance.ReligionsManager.HasBlessing(capturerHero, DefaultDivinities.Instance.Osric))
             {
                 FeudalTitle title = BannerKingsConfig.Instance.TitleManager.GetTitle(settlement);


### PR DESCRIPTION
For my faction mod https://www.nexusmods.com/mountandblade2bannerlord/mods/2774, at the start of the game I have an option that moves some Sturgia towns/castles to the new faction.

This causes an issue here, as there is no "CapturerHero" as the game has not fully loaded in yet. Adding a simple return statement here fixes the start game crash.