### PR TITLE
Adding Akiser Castle under Akkalat County

### DIFF
--- a/BannerKings/_Module/ModuleData/titles.xml
+++ b/BannerKings/_Module/ModuleData/titles.xml
@@ -228,6 +228,7 @@
 					<barony settlement="castle_K7" deJure="lord_6_19" />
 				</county>
 				<county settlement="town_K2" deJure="lord_6_16">
+					<barony settlement="castle_K2" deJure="lord_6_16" />
 					<barony settlement="castle_K8" deJure="lord_K9_l" />
 				</county>
 			</duchy>


### PR DESCRIPTION
Akiser Castle missed on the hierarchy tree of Khuzaits.
I added the Akiser Castle under Akkalat County.

Please review & merge if looks good.
Regards,
Kemal