### PR TITLE
Useful skills and perks

### DIFF
--- a/BannerKings/Managers/Skills/BKPerks.cs
+++ b/BannerKings/Managers/Skills/BKPerks.cs
@@ -22,7 +22,7 @@ namespace BannerKings.Managers.Skills
             275,
             300
         };
-
+     
         public HashSet<PerkObject> LifestylePerks { get; } = new();
 
         #region Fian
@@ -308,7 +308,7 @@ namespace BannerKings.Managers.Skills
 
             #region Courtier
 
-            CourtierAppointee.Initialize("{=Y5boR1SF}Appointee", 
+            CourtierAppointee.Initialize("{=Y5boR1SF}Appointee",
                 null,
                 80,
                 null,
@@ -346,8 +346,8 @@ namespace BannerKings.Managers.Skills
             #region Fian
 
             FianHighlander = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleFianHighlander"));
-            FianHighlander.Initialize("{=U7W2kGgA}Highlander", null, 
-                80, 
+            FianHighlander.Initialize("{=U7W2kGgA}Highlander", null,
+                80,
                 null,
                 "{=WgmJfTeR}Increases your movement speed by 5%.",
                 SkillEffect.PerkRole.Personal, 0.05f,
@@ -357,8 +357,8 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.EffectIncrementType.AddFactor);
 
             FianRanger = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleFianRanger"));
-            FianRanger.Initialize("{=w7GFfrAy}Ranger", null, 
-                160, 
+            FianRanger.Initialize("{=w7GFfrAy}Ranger", null,
+                160,
                 null,
                 "{=ZK5MjmMK}Increase maximum track life by 20%.",
                 SkillEffect.PerkRole.Personal, 0.05f,
@@ -368,8 +368,8 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.EffectIncrementType.AddFactor);
 
             FianFennid = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleFianFennid"));
-            FianFennid.Initialize("{=qvQEEEM4}Fénnid", null, 
-                240, 
+            FianFennid.Initialize("{=qvQEEEM4}Fénnid", null,
+                240,
                 null,
                 "{=4oCh1aji}You and your formation take aim 10% while on foot.",
                 SkillEffect.PerkRole.Personal, 0.05f,
@@ -421,7 +421,7 @@ namespace BannerKings.Managers.Skills
 
             CivilEngineer = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleCivilEngineer"));
             LifestylePerks.Add(CivilEngineer);
-            CivilEngineer.Initialize("{=M9R9NkrP}Civil Engineer", null, 
+            CivilEngineer.Initialize("{=M9R9NkrP}Civil Engineer", null,
                 80,
                 null,
                 "{=J6oPqQmt}Settlements have an additional catapult during siege start.",
@@ -433,8 +433,8 @@ namespace BannerKings.Managers.Skills
 
             CivilCultivator = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleCivilCultivator"));
             LifestylePerks.Add(CivilCultivator);
-            CivilCultivator.Initialize("{=phRxxa8X}Cultivator", null, 
-                160, 
+            CivilCultivator.Initialize("{=phRxxa8X}Cultivator", null,
+                160,
                 null,
                 "{=EH3ExMr9}Agricultural yield increases by flat 5%.",
                 SkillEffect.PerkRole.Personal, 0.05f,
@@ -446,8 +446,8 @@ namespace BannerKings.Managers.Skills
             CivilOverseer = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleCivilOverseer"));
             CivilManufacturer = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleCivilManufacturer"));
             LifestylePerks.Add(CivilOverseer);
-            CivilOverseer.Initialize("{=DZXXrNon}Overseer", null, 
-                320, 
+            CivilOverseer.Initialize("{=DZXXrNon}Overseer", null,
+                320,
                 null,
                 "{=zaVqT3bv}Stability increases by flat 5%.",
                 SkillEffect.PerkRole.Personal, 0.05f,
@@ -457,8 +457,8 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.EffectIncrementType.AddFactor);
 
             LifestylePerks.Add(CivilManufacturer);
-            CivilManufacturer.Initialize("{=UmFnG5z2}Manufacturer", null, 
-                240, 
+            CivilManufacturer.Initialize("{=UmFnG5z2}Manufacturer", null,
+                240,
                 null,
                 "{=UruYDkr2}Production efficiency increases by flat 15%.",
                 SkillEffect.PerkRole.Personal, 0.05f,
@@ -472,8 +472,8 @@ namespace BannerKings.Managers.Skills
             #region Siege
 
             SiegeEngineer = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleSiegeEngineer"));
-            SiegeEngineer.Initialize("{=brd9F4gY}Siege Engineer", null, 
-                80, 
+            SiegeEngineer.Initialize("{=brd9F4gY}Siege Engineer", null,
+                80,
                 null,
                 "{=2jDEHBg3}Get a pre-built ballista as attacker during siege.",
                 SkillEffect.PerkRole.Personal, 0.05f,
@@ -483,7 +483,7 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.EffectIncrementType.AddFactor);
 
             SiegePlanner = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleSiegePlanner"));
-            SiegePlanner.Initialize("{=VyzxZL7T}Siege Planner", null, 
+            SiegePlanner.Initialize("{=VyzxZL7T}Siege Planner", null,
                 160,
                 null,
                 "{=5jMZb0xZ}Ranged infantry deals 15% more damage in siege simulations.",
@@ -494,8 +494,8 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.EffectIncrementType.AddFactor);
 
             SiegeOverseer = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleSiegeOverseer"));
-            SiegeOverseer.Initialize("{=tWvXqDWY}Siege Overseer", null, 
-                240, 
+            SiegeOverseer.Initialize("{=tWvXqDWY}Siege Overseer", null,
+                240,
                 null,
                 "{=9SoSFu8s}Army consumes 15% less food during sieges, either attacking or defending.",
                 SkillEffect.PerkRole.Personal, 0.05f,
@@ -561,7 +561,7 @@ namespace BannerKings.Managers.Skills
             AugustDeFacto = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleAugustDeFacto"));
             LifestylePerks.Add(AugustDeFacto);
             AugustDeFacto.Initialize("{=Yy1wcNon}De Facto", null,
-                160, 
+                160,
                 null,
                 "{=J6oPqQmt}Settlement autonomy reduced by flat 3%.",
                 SkillEffect.PerkRole.Personal, 0.05f,
@@ -572,8 +572,8 @@ namespace BannerKings.Managers.Skills
 
             AugustDeJure = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleAugustDeJure"));
             LifestylePerks.Add(AugustDeJure);
-            AugustDeJure.Initialize("{=HRUBrSjM}De Jure", null, 
-                240, 
+            AugustDeJure.Initialize("{=HRUBrSjM}De Jure", null,
+                240,
                 null,
                 "{=nBZtX2R0}Demesne limit increased by 1.",
                 SkillEffect.PerkRole.Personal, 0.05f,
@@ -585,7 +585,7 @@ namespace BannerKings.Managers.Skills
             AugustKingOfKings = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleAugustKingOfKings"));
             LifestylePerks.Add(AugustKingOfKings);
             AugustKingOfKings.Initialize("{=6pfSPkvd}King of Kings", null,
-                320, 
+                320,
                 null,
                 "{=fyoL3m5n}If king level or higher, increase vassal limit by 2.",
                 SkillEffect.PerkRole.Personal, 0.05f,
@@ -601,7 +601,7 @@ namespace BannerKings.Managers.Skills
             CataphractEquites = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleCataphractEquites"));
             LifestylePerks.Add(CataphractEquites);
             CataphractEquites.Initialize("{=oYAOv2KP}Equites", null,
-                80, 
+                80,
                 null,
                 "{=BpFCxR6C}You and troops in your formation deal 10% more charge damage.",
                 SkillEffect.PerkRole.Captain, 4f,
@@ -613,7 +613,7 @@ namespace BannerKings.Managers.Skills
             CataphractAdaptiveTactics = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleCataphractAdaptiveTactics"));
             LifestylePerks.Add(CataphractAdaptiveTactics);
             CataphractAdaptiveTactics.Initialize("{=gg9Yxqfy}Adaptive Tactics", null,
-                160, 
+                160,
                 null,
                 "{=Pup1khtn}Increased damage on horseback with polearms, sidearms and bows by 5%.",
                 SkillEffect.PerkRole.Personal, 5f,
@@ -624,8 +624,8 @@ namespace BannerKings.Managers.Skills
 
             CataphractKlibanophoros = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleCataphractKlibanophori"));
             LifestylePerks.Add(CataphractKlibanophoros);
-            CataphractKlibanophoros.Initialize("{=iETO50gi}Klibanophori", null, 
-                240, 
+            CataphractKlibanophoros.Initialize("{=iETO50gi}Klibanophori", null,
+                240,
                 null,
                 "{=a2sO3wbW}You and troops in your formation receive 5% less damange when mounted.",
                 SkillEffect.PerkRole.Personal, 0.05f,
@@ -640,7 +640,7 @@ namespace BannerKings.Managers.Skills
 
             CaravaneerStrider = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleCaravaneerStrider"));
             LifestylePerks.Add(CaravaneerStrider);
-            CaravaneerStrider.Initialize("{=Nk505umn}Strider", null, 
+            CaravaneerStrider.Initialize("{=Nk505umn}Strider", null,
                 80,
                 null,
                 "{=s0zsXS2Z}Increases your movement speed by 3%.",
@@ -652,8 +652,8 @@ namespace BannerKings.Managers.Skills
 
             CaravaneerDealer = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleCaravaneerDealer"));
             LifestylePerks.Add(CaravaneerDealer);
-            CaravaneerDealer.Initialize("{=6yEOGwgd}Dealer", null, 
-                150, 
+            CaravaneerDealer.Initialize("{=6yEOGwgd}Dealer", null,
+                150,
                 null,
                 "{=njAV5qnr}Caravan wages are reduced by 10%.",
                 SkillEffect.PerkRole.PartyOwner, 10f,
@@ -663,8 +663,8 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.EffectIncrementType.AddFactor);
 
             CaravaneerOutsideConnections = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleCaravaneerOutsideConnections"));
-            CaravaneerOutsideConnections.Initialize("{=ZX0fpu3t}Outside Connections", null, 
-                240, 
+            CaravaneerOutsideConnections.Initialize("{=ZX0fpu3t}Outside Connections", null,
+                240,
                 null,
                 "{=0C3HpYf5}Your caravans have 5% less trade penalty.",
                 SkillEffect.PerkRole.PartyOwner, 5f,
@@ -678,8 +678,8 @@ namespace BannerKings.Managers.Skills
             #region Artisan
 
             ArtisanSmith = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleArtisanSmith"));
-            ArtisanSmith.Initialize("{=etbv7s6N}Smith", null, 
-                80, 
+            ArtisanSmith.Initialize("{=etbv7s6N}Smith", null,
+                80,
                 null,
                 "{=zOzu5By2}Crafting items costs 10% less energy.",
                 SkillEffect.PerkRole.Personal, 10f,
@@ -689,8 +689,8 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.EffectIncrementType.AddFactor);
 
             ArtisanCraftsman = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleArtisanCraftsman"));
-            ArtisanCraftsman.Initialize("{=iktjoMi1}Craftsman", null, 
-                160, 
+            ArtisanCraftsman.Initialize("{=iktjoMi1}Craftsman", null,
+                160,
                 null,
                 "{=3TB6TJvJ}Your workshops have 5% increase in production quality.",
                 SkillEffect.PerkRole.ClanLeader, 5f,
@@ -700,7 +700,7 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.EffectIncrementType.AddFactor);
 
             ArtisanEntrepeneur = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleArtisanEntrepeneur"));
-            ArtisanEntrepeneur.Initialize("{=hNHACmv9}Entrepeneur", null, 
+            ArtisanEntrepeneur.Initialize("{=hNHACmv9}Entrepeneur", null,
                 240,
                 null,
                 "{=qiMW8Wio}Increased settlement production efficiency by flat 10%.",
@@ -716,8 +716,8 @@ namespace BannerKings.Managers.Skills
 
             OutlawKidnapper = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleOutlawKidnapper"));
             LifestylePerks.Add(OutlawKidnapper);
-            OutlawKidnapper.Initialize("{=fWwFLnTw}Kidnapper", null, 
-                80, 
+            OutlawKidnapper.Initialize("{=fWwFLnTw}Kidnapper", null,
+                80,
                 null,
                 "{=kbBbDiyR}30% better deals reansoming lords.",
                 SkillEffect.PerkRole.PartyLeader, 3f,
@@ -740,7 +740,7 @@ namespace BannerKings.Managers.Skills
 
             OutlawNightPredator = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleOutlawNightPredator"));
             LifestylePerks.Add(OutlawNightPredator);
-            OutlawNightPredator.Initialize("{=JjE7nzmH}Night Predator", null, 
+            OutlawNightPredator.Initialize("{=JjE7nzmH}Night Predator", null,
                 240,
                 null,
                 "{=MB9f1s0O}Your party is 50% harder to spot in forests.",
@@ -752,8 +752,8 @@ namespace BannerKings.Managers.Skills
 
             OutlawUnderworldKing = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleOutlawUnderworldKing"));
             LifestylePerks.Add(OutlawUnderworldKing);
-            OutlawUnderworldKing.Initialize("{=OMefnnZ9}Underworld King", null, 
-                320, 
+            OutlawUnderworldKing.Initialize("{=OMefnnZ9}Underworld King", null,
+                320,
                 null,
                 "{=GpcWSVCy}Killing bandit leaders yields renown.",
                 SkillEffect.PerkRole.Personal, 10f,
@@ -767,8 +767,8 @@ namespace BannerKings.Managers.Skills
             #region Mercenary
 
             MercenaryLocalConnections = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleMercenaryLocalConnections"));
-            MercenaryLocalConnections.Initialize("{=8XeyqTNh}Local Connections", null, 
-                80, 
+            MercenaryLocalConnections.Initialize("{=8XeyqTNh}Local Connections", null,
+                80,
                 null,
                 "{=jhZ8TFCB}While serving as mercenary, gain the ability to recruit from local minor factions in towns.",
                 SkillEffect.PerkRole.PartyLeader, 3f,
@@ -778,8 +778,8 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.EffectIncrementType.AddFactor);
 
             MercenaryRansacker = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleMercenaryRansacker"));
-            MercenaryRansacker.Initialize("{=n9ZMPe6w}Ransacker", null, 
-                160, 
+            MercenaryRansacker.Initialize("{=n9ZMPe6w}Ransacker", null,
+                160,
                 null,
                 "{=TAfrnnO4}Killing enemies provides 10% more share battle contribution.",
                 SkillEffect.PerkRole.PartyOwner, 10f,
@@ -789,8 +789,8 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.EffectIncrementType.AddFactor);
 
             MercenaryFamousSellswords = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LifestyleMercenarySellswords"));
-            MercenaryFamousSellswords.Initialize("{=976FNbqA}Famous Sellswords", null, 
-                240, 
+            MercenaryFamousSellswords.Initialize("{=976FNbqA}Famous Sellswords", null,
+                240,
                 null,
                 "{=EkFaisgP}Influence award for army participation increased by 30%.",
                 SkillEffect.PerkRole.Personal, 10f,
@@ -922,7 +922,7 @@ namespace BannerKings.Managers.Skills
             #region Theology
 
             TheologyFaithful = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("TheologyFaithful"));
-            TheologyFaithful.Initialize("{=mnpTkVYf}Faithful", BKSkills.Instance.Theology, 
+            TheologyFaithful.Initialize("{=mnpTkVYf}Faithful", BKSkills.Instance.Theology,
                 GetTierCost(1),
                 LordshipAdaptive,
                 "{=8zbXJZWL}Piety gain is increased by +0.2 daily.",
@@ -933,7 +933,7 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.EffectIncrementType.Add);
 
             TheologyBlessed = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("TheologyBlessed"));
-            TheologyBlessed.Initialize("{=hmysbhA8}Blessed", BKSkills.Instance.Theology, 
+            TheologyBlessed.Initialize("{=hmysbhA8}Blessed", BKSkills.Instance.Theology,
                 GetTierCost(2),
                 LordshipAdaptive,
                 "{=p2ekwXZR}Blessings last a season longer.",
@@ -944,7 +944,7 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.EffectIncrementType.Add);
 
             TheologyReligiousTeachings = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("TheologyReligiousTeachings"));
-            TheologyReligiousTeachings.Initialize("{=jAXfadxv}Religious Teachings", BKSkills.Instance.Theology, 
+            TheologyReligiousTeachings.Initialize("{=jAXfadxv}Religious Teachings", BKSkills.Instance.Theology,
                 GetTierCost(3),
                 LordshipAdaptive,
                 "{=c7v8hrEa}Children receive 1 extra Wisdom when becoming adults.",
@@ -957,7 +957,7 @@ namespace BannerKings.Managers.Skills
             TheologyRitesOfPassage = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("TheologyRitesOfPassage"));
             TheologyPreacher = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("TheologyPreacher"));
 
-            TheologyPreacher.Initialize("{=9TwjtYhb}Preacher", BKSkills.Instance.Theology, 
+            TheologyPreacher.Initialize("{=9TwjtYhb}Preacher", BKSkills.Instance.Theology,
                 GetTierCost(4),
                 TheologyRitesOfPassage,
                 "{=J6oPqQmt}Settlement religious tensions reduced by X%.",
@@ -967,7 +967,7 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.PerkRole.Ruler, 1f,
                 SkillEffect.EffectIncrementType.Add);
 
-            TheologyRitesOfPassage.Initialize("{=or8rXdjy}Rites Of Passage", BKSkills.Instance.Theology, 
+            TheologyRitesOfPassage.Initialize("{=or8rXdjy}Rites Of Passage", BKSkills.Instance.Theology,
                 GetTierCost(4),
                 TheologyPreacher,
                 "{=mbfGsOCE}Rites can be performed again 1 season sooner.",
@@ -978,7 +978,7 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.EffectIncrementType.Add);
 
             TheologyLithurgy = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("TheologyLithurgy"));
-            TheologyLithurgy.Initialize("{=n3FhFzTo}Lithurgy", BKSkills.Instance.Theology, 
+            TheologyLithurgy.Initialize("{=n3FhFzTo}Lithurgy", BKSkills.Instance.Theology,
                 GetTierCost(5),
                 null,
                 "{=4hNMnjUh}Randomly receive relations with religious notables in your settlements.",
@@ -994,7 +994,7 @@ namespace BannerKings.Managers.Skills
 
             LordshipTraditionalist = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LordshipTraditionalist"));
             LordshipAdaptive = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LordshipAdaptive"));
-            LordshipTraditionalist.Initialize("{=uVzu9bd1}Traditionalist", BKSkills.Instance.Lordship, 
+            LordshipTraditionalist.Initialize("{=uVzu9bd1}Traditionalist", BKSkills.Instance.Lordship,
                 GetTierCost(1),
                 LordshipAdaptive,
                 "{=rEZSUexA}Increased cultural assimilation speed by 10%",
@@ -1016,8 +1016,8 @@ namespace BannerKings.Managers.Skills
 
             LordshipAccolade = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LordshipAccolade"));
             LordshipManorLord = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LordshipManorLord"));
-            LordshipAccolade.Initialize("{=o6kuCQHW}Accolade", BKSkills.Instance.Lordship, 
-                GetTierCost(2), 
+            LordshipAccolade.Initialize("{=o6kuCQHW}Accolade", BKSkills.Instance.Lordship,
+                GetTierCost(2),
                 LordshipManorLord,
                 "{=KynB5Njq}Knighting requires 15% less influence",
                 SkillEffect.PerkRole.Ruler, -0.15f,
@@ -1026,8 +1026,8 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.PerkRole.Ruler, 1f,
                 SkillEffect.EffectIncrementType.Add);
 
-            LordshipManorLord.Initialize("{=XUu53n1F}Manor Lord", BKSkills.Instance.Lordship, 
-                GetTierCost(2), 
+            LordshipManorLord.Initialize("{=XUu53n1F}Manor Lord", BKSkills.Instance.Lordship,
+                GetTierCost(2),
                 LordshipAccolade,
                 "{=uanVb5h8}Villages weigh 20% less in demesne limit",
                 SkillEffect.PerkRole.Ruler, -0.20f,
@@ -1038,8 +1038,8 @@ namespace BannerKings.Managers.Skills
 
             LordshipMilitaryAdministration = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LordshipMilitaryAdministration"));
             LordshipEconomicAdministration = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LordshipEconomicAdministration"));
-            LordshipMilitaryAdministration.Initialize("{=wzJW8mFC}Military Administration", BKSkills.Instance.Lordship, 
-                GetTierCost(3), 
+            LordshipMilitaryAdministration.Initialize("{=wzJW8mFC}Military Administration", BKSkills.Instance.Lordship,
+                GetTierCost(3),
                 LordshipEconomicAdministration,
                 "{=tqWtfNch}Increased settlement militarism in settlements by 2%",
                 SkillEffect.PerkRole.Ruler, 0.02f,
@@ -1048,7 +1048,7 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.PerkRole.Ruler, 0.2f,
                 SkillEffect.EffectIncrementType.AddFactor);
 
-            LordshipEconomicAdministration.Initialize("{=SEB2hNAG}Economic Administration", BKSkills.Instance.Lordship, 
+            LordshipEconomicAdministration.Initialize("{=SEB2hNAG}Economic Administration", BKSkills.Instance.Lordship,
                 GetTierCost(3),
                 LordshipMilitaryAdministration,
                 "{=w2KEdfGJ}Increased settlement production efficiency by 10%",
@@ -1060,8 +1060,8 @@ namespace BannerKings.Managers.Skills
 
             LordshipClaimant = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LordshipClaimant"));
             LordshipPatron = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("LordshipPatron"));
-            LordshipClaimant.Initialize("{=6hY9WysN}Claimant", BKSkills.Instance.Lordship, 
-                GetTierCost(4), 
+            LordshipClaimant.Initialize("{=6hY9WysN}Claimant", BKSkills.Instance.Lordship,
+                GetTierCost(4),
                 LordshipPatron,
                 "{=6hY9WysN}Claims are built 30% faster",
                 SkillEffect.PerkRole.Ruler, 0.3f,
@@ -1070,7 +1070,7 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.PerkRole.Ruler, 0.05f,
                 SkillEffect.EffectIncrementType.AddFactor);
 
-            LordshipPatron.Initialize("{=aHL9od5c}Patron", BKSkills.Instance.Lordship, 
+            LordshipPatron.Initialize("{=aHL9od5c}Patron", BKSkills.Instance.Lordship,
                 GetTierCost(4),
                 LordshipClaimant,
                 "{=moMBKpGt}Grating titles yields renown",
@@ -1085,19 +1085,19 @@ namespace BannerKings.Managers.Skills
             #region Scholarship
 
             ScholarshipLiterate = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("ScholarshipLiterate"));
-            ScholarshipLiterate.Initialize("{=EFGT3zVR}Literate", BKSkills.Instance.Scholarship, 
-                GetTierCost(1), 
+            ScholarshipLiterate.Initialize("{=EFGT3zVR}Literate", BKSkills.Instance.Scholarship,
+                GetTierCost(1),
                 null,
-                "{=bm513T3G}Allows reading books", 
+                "{=bm513T3G}Allows reading books",
                 SkillEffect.PerkRole.Personal, 0f,
-                SkillEffect.EffectIncrementType.Invalid, 
+                SkillEffect.EffectIncrementType.Invalid,
                 string.Empty,
                 SkillEffect.PerkRole.None, 0f,
                 SkillEffect.EffectIncrementType.Invalid);
 
             ScholarshipAvidLearner = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("ScholarshipLearner"));
-            ScholarshipAvidLearner.Initialize("{=tmS5CdWA}Avid Learner", BKSkills.Instance.Scholarship, 
-                GetTierCost(2), 
+            ScholarshipAvidLearner.Initialize("{=tmS5CdWA}Avid Learner", BKSkills.Instance.Scholarship,
+                GetTierCost(2),
                 null,
                 "{=JNDa4Q9N}Increase language learning rate",
                 SkillEffect.PerkRole.Personal, 20f,
@@ -1107,8 +1107,8 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.EffectIncrementType.Add);
 
             ScholarshipTutor = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("ScholarshipTutor"));
-            ScholarshipTutor.Initialize("{=T5khtP0R}Tutor", BKSkills.Instance.Scholarship, 
-                GetTierCost(3), 
+            ScholarshipTutor.Initialize("{=T5khtP0R}Tutor", BKSkills.Instance.Scholarship,
+                GetTierCost(3),
                 null,
                 "{=uXF06oDk}Additional attribute point to clan children coming of age.",
                 SkillEffect.PerkRole.ClanLeader, 1f,
@@ -1118,8 +1118,8 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.EffectIncrementType.AddFactor);
 
             ScholarshipWellRead = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("ScholarshipWellRead"));
-            ScholarshipWellRead.Initialize("{=ntTyYVuH}Well Read", BKSkills.Instance.Scholarship, 
-                GetTierCost(4), 
+            ScholarshipWellRead.Initialize("{=ntTyYVuH}Well Read", BKSkills.Instance.Scholarship,
+                GetTierCost(4),
                 null,
                 "{=BfnH3yR4}Increased reading rates for books",
                 SkillEffect.PerkRole.Personal, 12f,
@@ -1130,7 +1130,7 @@ namespace BannerKings.Managers.Skills
 
             ScholarshipAccountant = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("ScholarshipAccountant"));
             ScholarshipMechanic = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("ScholarshipMechanic"));
-            ScholarshipMechanic.Initialize("{=BUyRc4AY}Mechanic", BKSkills.Instance.Scholarship, 
+            ScholarshipMechanic.Initialize("{=BUyRc4AY}Mechanic", BKSkills.Instance.Scholarship,
                 GetTierCost(5),
                 ScholarshipAccountant,
                 "{=iY5A6B2Y}Engineering skill tree yields both perks rather than 1",
@@ -1140,7 +1140,7 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.PerkRole.None, 0f,
                 SkillEffect.EffectIncrementType.Invalid);
 
-            ScholarshipAccountant.Initialize("{=o8yaA6r6}Accountant", BKSkills.Instance.Scholarship, 
+            ScholarshipAccountant.Initialize("{=o8yaA6r6}Accountant", BKSkills.Instance.Scholarship,
                 GetTierCost(5),
                 ScholarshipMechanic,
                 "{=zQT8PzBc}Stewardship skill tree yields both perks rather than 1",
@@ -1163,7 +1163,7 @@ namespace BannerKings.Managers.Skills
 
             ScholarshipBookWorm = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("ScholarshipBookWorm"));
             ScholarshipBookWorm.Initialize("{=4S4MV14E}Book Worm", BKSkills.Instance.Scholarship,
-                GetTierCost(7), 
+                GetTierCost(7),
                 null,
                 "{=BfnH3yR4}Increased reading rates for books",
                 SkillEffect.PerkRole.Personal, 20f,
@@ -1171,10 +1171,10 @@ namespace BannerKings.Managers.Skills
                 "{=iE5hXmjw}Language limit is increased by 1",
                 SkillEffect.PerkRole.Personal, 1f,
                 SkillEffect.EffectIncrementType.Add);
-             
+
             ScholarshipPeerReview = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("ScholarshipPeerReview"));
-            ScholarshipPeerReview.Initialize("{=o2cMkCJt}Peer Review", BKSkills.Instance.Scholarship, 
-                GetTierCost(8), 
+            ScholarshipPeerReview.Initialize("{=o2cMkCJt}Peer Review", BKSkills.Instance.Scholarship,
+                GetTierCost(8),
                 null,
                 "{=XdiiPz1L}Clan settlements yield more research points",
                 SkillEffect.PerkRole.Personal, 20f,
@@ -1185,7 +1185,7 @@ namespace BannerKings.Managers.Skills
 
             ScholarshipBedTimeStory = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("ScholarshipBedTimeStory"));
             ScholarshipBedTimeStory.Initialize("{=S8D75zGm}Bed Time Story", BKSkills.Instance.Scholarship,
-                GetTierCost(9), 
+                GetTierCost(9),
                 null,
                 "{=dsaqAcgd}Daily experience points in random skill for companions and family in party",
                 SkillEffect.PerkRole.PartyLeader, 10f,
@@ -1196,7 +1196,7 @@ namespace BannerKings.Managers.Skills
 
             ScholarshipTreasurer = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("ScholarshipTreasurer"));
             ScholarshipNaturalScientist = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("ScholarshipNaturalScientist"));
-            ScholarshipTreasurer.Initialize("{=G0HZtZGF}Treasurer", BKSkills.Instance.Scholarship, 
+            ScholarshipTreasurer.Initialize("{=G0HZtZGF}Treasurer", BKSkills.Instance.Scholarship,
                 GetTierCost(10),
                 ScholarshipNaturalScientist,
                 "{=at3o6Jsb}Trade skill tree yields both perks rather than 1",
@@ -1216,7 +1216,7 @@ namespace BannerKings.Managers.Skills
                 SkillEffect.EffectIncrementType.Invalid);
 
             ScholarshipPolyglot = Game.Current.ObjectManager.RegisterPresumedObject(new PerkObject("ScholarshipPolyglot"));
-            ScholarshipPolyglot.Initialize("{=LbpgEp03}Polyglot", BKSkills.Instance.Scholarship, 
+            ScholarshipPolyglot.Initialize("{=LbpgEp03}Polyglot", BKSkills.Instance.Scholarship,
                 GetTierCost(11),
                 null,
                 "{=28gM5dpU}Language limit is increased by 2", SkillEffect.PerkRole.Personal, 10f,
@@ -1238,7 +1238,7 @@ namespace BannerKings.Managers.Skills
             #endregion Scholarship
         }
 
-        private static int GetTierCost(int tierIndex)
+        public static int GetTierCost(int tierIndex)
         {
             return Requirements[tierIndex - 1];
         }

--- a/BannerKings/Models/Vanilla/BKCompanionPrices.cs
+++ b/BannerKings/Models/Vanilla/BKCompanionPrices.cs
@@ -1,9 +1,12 @@
-﻿using Helpers;
+﻿using BannerKings.Settings;
+using BannerKings.Utils;
+using Helpers;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CharacterDevelopment;
 using TaleWorlds.CampaignSystem.Extensions;
 using TaleWorlds.CampaignSystem.GameComponents;
 using TaleWorlds.Core;
+using TaleWorlds.Library;
 using TaleWorlds.ObjectSystem;
 
 namespace BannerKings.Models.Vanilla
@@ -11,7 +14,7 @@ namespace BannerKings.Models.Vanilla
     public class BKCompanionPrices : DefaultCompanionHiringPriceCalculationModel
     {
         public override int GetCompanionHiringPrice(Hero companion) => GetHiringPrice(companion, true);
-        
+
 
         public int GetHiringPrice(Hero companion, bool addGearCosts)
         {
@@ -51,7 +54,7 @@ namespace BannerKings.Models.Vanilla
 
                 explainedNumber.Add(num / 2f);
             }
-            
+
             explainedNumber.Add(companion.CharacterObject.Level * 10);
             var skills = MBObjectManager.Instance.GetObjectTypeList<SkillObject>();
             foreach (var skill in skills)
@@ -63,10 +66,22 @@ namespace BannerKings.Models.Vanilla
                 }
             }
 
+            #region Steward.PaidInPromise 
             if (Hero.MainHero.IsPartyLeader && Hero.MainHero.GetPerkValue(DefaultPerks.Steward.PaidInPromise))
             {
-                explainedNumber.AddFactor(DefaultPerks.Steward.PaidInPromise.PrimaryBonus * 0.01f);
+                if (BannerKingsSettings.Instance.EnableUsefulPerks && BannerKingsSettings.Instance.EnableUsefulStewardPerks)
+                {
+
+                    DefaultPerks.Steward.PaidInPromise.AddScaledPersonlOrClanLeaderPerkBonusWithClanAndFamilyMembers(ref explainedNumber, false, Hero.MainHero, DefaultSkills.Steward, 20, 100, 0, minValue: -0.4f, maxValue: 0);
+                }
+                else
+                {
+
+                    explainedNumber.AddFactor(DefaultPerks.Steward.PaidInPromise.PrimaryBonus * 0.01f, null);
+
+                }
             }
+            #endregion
 
             if (Hero.MainHero.PartyBelongedTo != null)
             {
@@ -89,7 +104,8 @@ namespace BannerKings.Models.Vanilla
                 }
             }
 
-            return MBRandom.RoundRandomized(totalCost * 0.005f);
+            return MathF.Round(totalCost * 0.005f);
+            //return MBRandom.RoundRandomized(totalCost * 0.005f);//party wage keep changing every hour because of random value
         }
 
         public int GetCostFactor(SkillObject skill)

--- a/BannerKings/Models/Vanilla/BKMilitiaModel.cs
+++ b/BannerKings/Models/Vanilla/BKMilitiaModel.cs
@@ -15,6 +15,10 @@ using BannerKings.Managers.Court.Members;
 using BannerKings.Managers.Court.Members.Tasks;
 using BannerKings.Managers.Titles.Governments;
 using BannerKings.Managers.Titles;
+using TaleWorlds.CampaignSystem.CharacterDevelopment;
+using BannerKings.Settings;
+using BannerKings.Utils;
+using TaleWorlds.Core;
 
 namespace BannerKings.Models.Vanilla
 {
@@ -106,7 +110,7 @@ namespace BannerKings.Models.Vanilla
             }
 
             var education = BannerKingsConfig.Instance.EducationManager.GetHeroEducation(settlement.OwnerClan.Leader);
-            if (settlement.Culture.StringId == "battania" && education.Lifestyle != null && 
+            if (settlement.Culture.StringId == "battania" && education.Lifestyle != null &&
                 education.Lifestyle.Equals(DefaultLifestyles.Instance.Fian))
             {
                 baseResult.Add(1.5f, DefaultLifestyles.Instance.Fian.Name);
@@ -125,11 +129,26 @@ namespace BannerKings.Models.Vanilla
                 }
             }
 
-            BannerKingsConfig.Instance.CourtManager.ApplyCouncilEffect(ref baseResult, 
+            #region DefaultPerks.Steward.SevenVeterans
+            if (BannerKingsSettings.Instance.EnableUsefulPerks && BannerKingsSettings.Instance.EnableUsefulStewardPerks)
+            {
+                if (settlement.IsTown || settlement.IsCastle)
+                {
+                    if (settlement.Town.Governor != null && settlement.Town.Governor.GetPerkValue(DefaultPerks.Steward.SevenVeterans) && settlement.Town.Governor.CurrentSettlement != null && settlement.Town.Governor.CurrentSettlement == settlement)
+                    {
+                        baseResult.Add(-DefaultPerks.Steward.SevenVeterans.SecondaryBonus, DefaultPerks.Steward.SevenVeterans.Name);
+                    }
+                    DefaultPerks.Steward.SevenVeterans.AddScaledGovernerPerkBonusForTownWithTownHeros(ref baseResult, settlement.Town, DefaultSkills.Steward, 50, 100, 150, minValue: 0, maxValue: 10f);
+                }
+
+            }
+            #endregion
+
+            BannerKingsConfig.Instance.CourtManager.ApplyCouncilEffect(ref baseResult,
                 settlement.OwnerClan.Leader,
                 DefaultCouncilPositions.Instance.Marshal,
                 DefaultCouncilTasks.Instance.OrganizeMiltia,
-                1f, 
+                1f,
                 false);
 
             return baseResult;
@@ -156,9 +175,9 @@ namespace BannerKings.Models.Vanilla
             return result;
         }
 
-        public override float CalculateEliteMilitiaSpawnChance(Settlement settlement) => 
+        public override float CalculateEliteMilitiaSpawnChance(Settlement settlement) =>
             MilitiaSpawnChanceExplained(settlement).ResultNumber;
-        
+
         public ExplainedNumber MilitiaSpawnChanceExplained(Settlement settlement)
         {
             var result =

--- a/BannerKings/Models/Vanilla/BKPartyConsumptionModel.cs
+++ b/BannerKings/Models/Vanilla/BKPartyConsumptionModel.cs
@@ -2,6 +2,7 @@ using BannerKings.Components;
 using BannerKings.Managers.Education.Lifestyles;
 using BannerKings.Managers.Skills;
 using BannerKings.Settings;
+using BannerKings.Utils;
 using Helpers;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CharacterDevelopment;
@@ -15,14 +16,14 @@ namespace BannerKings.Models.Vanilla
 {
     public class BKPartyConsumptionModel : PartyFoodModel
     {
-        public override int NumberOfMenOnMapToEatOneFood 
-        { 
+        public override int NumberOfMenOnMapToEatOneFood
+        {
             get
             {
                 int result = 20;
                 result += (int)(BannerKingsSettings.Instance.SlowerParties * 20f);
                 return result;
-            } 
+            }
         }
 
         public override float BirdFood => 0.025f;
@@ -115,7 +116,18 @@ namespace BannerKings.Models.Vanilla
                 result.Add(value, DefaultPerks.Roguery.Promises.Name, null);
             }
             PerkHelper.AddPerkBonusForParty(DefaultPerks.Athletics.Spartan, party, false, ref result);
-            PerkHelper.AddPerkBonusForParty(DefaultPerks.Steward.WarriorsDiet, party, true, ref result);
+
+            #region DefaultPerks.Steward.WarriorsDiet
+            if (BannerKingsSettings.Instance.EnableUsefulPerks && BannerKingsSettings.Instance.EnableUsefulStewardPerks)
+            {        
+                DefaultPerks.Steward.WarriorsDiet.AddScaledPerkBonus(ref result, false, party,  DefaultSkills.Steward, 0, 15, 100, Utils.Helpers.SkillScale.OnlyQuartermaster, minValue: -0.3f, maxValue:0);
+            }
+            else
+            {
+                PerkHelper.AddPerkBonusForParty(DefaultPerks.Steward.WarriorsDiet, party, true, ref result);
+            }
+            #endregion
+
             if (party.EffectiveQuartermaster != null)
             {
                 PerkHelper.AddEpicPerkBonusForCharacter(DefaultPerks.Steward.PriceOfLoyalty, party.EffectiveQuartermaster.CharacterObject, DefaultSkills.Steward, true, ref result, 250);
@@ -129,10 +141,31 @@ namespace BannerKings.Models.Vanilla
             {
                 PerkHelper.AddPerkBonusForTown(DefaultPerks.Athletics.StrongLegs, party.CurrentSettlement.Town, ref result);
             }
+
+            #region DefaultPerks.Steward.StiffUpperLip
             if (party.Army != null)
             {
-                PerkHelper.AddPerkBonusForParty(DefaultPerks.Steward.StiffUpperLip, party, true, ref result);
+                if (BannerKingsSettings.Instance.EnableUsefulPerks && BannerKingsSettings.Instance.EnableUsefulStewardPerks)
+                {
+                    DefaultPerks.Steward.StiffUpperLip.AddScaledPerkBonus(ref result, false, party, DefaultSkills.Steward, 0, 15, 100, Utils.Helpers.SkillScale.OnlyQuartermaster, minValue: -0.3f, maxValue: 0);
+                }
+                else
+                {
+                    PerkHelper.AddPerkBonusForParty(DefaultPerks.Steward.StiffUpperLip, party, true, ref result);
+                }
             }
+            #endregion
+            #region DefaultPerks.Steward.WarriorsDiet
+            if (BannerKingsSettings.Instance.EnableUsefulPerks && BannerKingsSettings.Instance.EnableUsefulStewardPerks)
+            {
+                DefaultPerks.Steward.WarriorsDiet.AddScaledPerkBonus(ref result, false, party, DefaultSkills.Steward, 0, 15, 100, Utils.Helpers.SkillScale.OnlyQuartermaster, minValue: -0.3f, maxValue: 0);
+            }
+            else
+            {
+                PerkHelper.AddPerkBonusForParty(DefaultPerks.Steward.WarriorsDiet, party, true, ref result);
+            }
+            #endregion
+
             SiegeEvent siegeEvent = party.SiegeEvent;
             if (((siegeEvent != null) ? siegeEvent.BesiegerCamp : null) != null)
             {

--- a/BannerKings/Models/Vanilla/BKPartyTrainningModel.cs
+++ b/BannerKings/Models/Vanilla/BKPartyTrainningModel.cs
@@ -1,11 +1,14 @@
-﻿using BannerKings.Utils;
+﻿using BannerKings.Settings;
+using BannerKings.Utils;
 using Helpers;
+using System.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CharacterDevelopment;
 using TaleWorlds.CampaignSystem.GameComponents;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Core;
 using TaleWorlds.Library;
 
 namespace BannerKings.Models.Vanilla
@@ -28,7 +31,7 @@ namespace BannerKings.Models.Vanilla
 
         public override ExplainedNumber GetEffectiveDailyExperience(MobileParty mobileParty, TroopRosterElement troop)
         {
-            ExplainedNumber result = default(ExplainedNumber);
+            ExplainedNumber result = default;
             ExceptionUtils.TryCatch(() =>
             {
                 if (troop.Character.Culture == null) return;
@@ -99,14 +102,39 @@ namespace BannerKings.Models.Vanilla
                         PerkHelper.AddPerkBonusForParty(DefaultPerks.Scouting.Unburdened, mobileParty, false, ref result);
                     }
                 }
-                if (mobileParty.IsActive && mobileParty.HasPerk(DefaultPerks.Steward.SevenVeterans, false) && troop.Character.Tier >= 4)
+                #region DefaultPerks.Steward.SevenVeterans
+                if (BannerKingsSettings.Instance.EnableUsefulPerks && BannerKingsSettings.Instance.EnableUsefulStewardPerks)
                 {
-                    result.Add((float)this.GetPerkExperiencesForTroops(DefaultPerks.Steward.SevenVeterans), null, null);
+                    if (mobileParty.IsActive && troop.Character.Tier >= 4)
+                    {
+                        DefaultPerks.Steward.SevenVeterans.AddScaledPerkBonus(ref result, false, mobileParty, DefaultSkills.Steward, 25, 25, 100, Utils.Helpers.SkillScale.Both, minValue: 0, maxValue: 60f);
+                    }
                 }
-                if (mobileParty.IsActive && mobileParty.HasPerk(DefaultPerks.Steward.DrillSergant, false))
+                else
                 {
-                    result.Add((float)this.GetPerkExperiencesForTroops(DefaultPerks.Steward.DrillSergant), null, null);
+                    if (mobileParty.IsActive && mobileParty.HasPerk(DefaultPerks.Steward.SevenVeterans, false) && troop.Character.Tier >= 4)
+                    {
+                        result.Add((float)this.GetPerkExperiencesForTroops(DefaultPerks.Steward.SevenVeterans), null, null);
+                    }
                 }
+                #endregion
+                #region DefaultPerks.Steward.DrillSergant
+                if (BannerKingsSettings.Instance.EnableUsefulPerks && BannerKingsSettings.Instance.EnableUsefulStewardPerks)
+                {
+                    if (mobileParty.IsActive)
+                    {
+                        DefaultPerks.Steward.DrillSergant.AddScaledPerkBonus(ref result, false, mobileParty, DefaultSkills.Steward, 25, 25, 100, Utils.Helpers.SkillScale.Both, minValue: 0, maxValue: 30f);
+                    }
+                }
+                else
+                {
+                    if (mobileParty.IsActive && mobileParty.HasPerk(DefaultPerks.Steward.DrillSergant, false))
+                    {
+                        result.Add((float)this.GetPerkExperiencesForTroops(DefaultPerks.Steward.DrillSergant), null, null);
+                    }
+                }
+                #endregion
+
                 if (troop.Character.Culture.IsBandit)
                 {
                     PerkHelper.AddPerkBonusForParty(DefaultPerks.Roguery.NoRestForTheWicked, mobileParty, true, ref result);
@@ -114,7 +142,7 @@ namespace BannerKings.Models.Vanilla
             },
             GetType().Name,
             false);
-           
+
             return result;
         }
     }

--- a/BannerKings/Models/Vanilla/BKWorkshopModel.cs
+++ b/BannerKings/Models/Vanilla/BKWorkshopModel.cs
@@ -2,7 +2,11 @@ using BannerKings.Behaviours.Workshops;
 using BannerKings.Extensions;
 using BannerKings.Managers.Policies;
 using BannerKings.Managers.Skills;
+using BannerKings.Settings;
+using BannerKings.Utils;
+using Helpers;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.CharacterDevelopment;
 using TaleWorlds.CampaignSystem.GameComponents;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.CampaignSystem.Settlements.Workshops;
@@ -14,7 +18,35 @@ namespace BannerKings.Models.Vanilla
     public class BKWorkshopModel : DefaultWorkshopModel
     {
         public override int DefaultWorkshopCountInSettlement => 6;
+        public override ExplainedNumber GetEffectiveConversionSpeedOfProduction(Workshop workshop, float speed, bool includeDescription)
+        {
+            ExplainedNumber result = new ExplainedNumber(speed, includeDescription, new TextObject("{=basevalue}Base", null));
+            Settlement settlement = workshop.Settlement;
+            if (settlement.OwnerClan.Kingdom != null)
+            {
+                if (settlement.OwnerClan.Kingdom.ActivePolicies.Contains(DefaultPolicies.ForgivenessOfDebts))
+                {
+                    result.AddFactor(-0.05f, DefaultPolicies.ForgivenessOfDebts.Name);
+                }
+                if (settlement.OwnerClan.Kingdom.ActivePolicies.Contains(DefaultPolicies.StateMonopolies))
+                {
+                    result.AddFactor(-0.1f, DefaultPolicies.StateMonopolies.Name);
+                }
+            }
+            PerkHelper.AddPerkBonusForTown(DefaultPerks.Trade.MercenaryConnections, settlement.Town, ref result);
 
+            #region DefaultPerks.Steward.Sweatshops
+            if (BannerKingsSettings.Instance.EnableUsefulPerks && BannerKingsSettings.Instance.EnableUsefulStewardPerks)
+            {
+                DefaultPerks.Steward.Sweatshops.AddScaledPersonlOrClanLeaderPerkBonusWithClanAndFamilyMembers(ref result, false, workshop.Owner, DefaultSkills.Steward, 10, 40, 100, minValue: 0, maxValue: 1f);
+            }
+            else
+            {
+                PerkHelper.AddPerkBonusForCharacter(DefaultPerks.Steward.Sweatshops, workshop.Owner.CharacterObject, true, ref result);
+            }
+            #endregion
+            return result;
+        }
         public int GetUpgradeCost(Workshop workshop)
         {
             return GetCostForPlayer(workshop) / (4 + workshop.Level());
@@ -87,7 +119,7 @@ namespace BannerKings.Models.Vanilla
         {
             float result = base.GetCostForPlayer(workshop);
             result += (int)(GetDailyExpense(workshop).ResultNumber * 15f * CampaignTime.DaysInYear);
-            
+
             if (workshop.Owner.OwnedWorkshops.Count == 1)
             {
                 result *= 1.15f;
@@ -104,7 +136,7 @@ namespace BannerKings.Models.Vanilla
 
         public ExplainedNumber GetBuyingCostExplained(Workshop workshop, Hero buyer, bool descriptions = false)
         {
-            ExplainedNumber result = new ExplainedNumber(base.GetCostForPlayer(workshop), descriptions, 
+            ExplainedNumber result = new ExplainedNumber(base.GetCostForPlayer(workshop), descriptions,
                 new TextObject("{=LiC18pJC}Equipment costs"));
             result.Add((int)(GetDailyExpense(workshop).ResultNumber * 15f * CampaignTime.DaysInYear),
                 new TextObject("{=hwVR2ej5}Employee wages"));
@@ -148,9 +180,9 @@ namespace BannerKings.Models.Vanilla
         public ExplainedNumber GetProductionEfficiency(Workshop workshop, bool explanations = false)
         {
             var result = new ExplainedNumber(0f, explanations);
-            result.Add(BannerKingsConfig.Instance.EconomyModel.CalculateProductionEfficiency(workshop.Settlement, false, workshop.Settlement.PopulationData()).ResultNumber, 
+            result.Add(BannerKingsConfig.Instance.EconomyModel.CalculateProductionEfficiency(workshop.Settlement, false, workshop.Settlement.PopulationData()).ResultNumber,
                 new TextObject("{=2fCjZALt}Local production efficiency"));
-            
+
             if (workshop.Level() > 1)
             {
                 result.AddFactor((workshop.Level() - 1) * 0.08f, GameTexts.FindText("str_level"));
@@ -199,7 +231,7 @@ namespace BannerKings.Models.Vanilla
             {
                 result.AddFactor(data.EconomicData.Mercantilism.ResultNumber * -0.5f);
             }
-            
+
             return result;
         }
     }

--- a/BannerKings/Patches/PerksPatches.cs
+++ b/BannerKings/Patches/PerksPatches.cs
@@ -1,0 +1,322 @@
+﻿using HarmonyLib;
+using Helpers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TaleWorlds.CampaignSystem.CharacterDevelopment;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.Localization;
+using BannerKings.Utils;
+using BannerKings.Settings;
+using TaleWorlds.Library;
+using TaleWorlds.CampaignSystem.ViewModelCollection;
+using BannerKings.Managers.Skills;
+
+namespace BannerKings.Patches
+{
+    internal class PerksPatches
+    {
+        [HarmonyPatch(typeof(CampaignUIHelper), "GetPerkRoleText")]
+        class GetPerkRoleTextPatch
+        {
+            static void Postfix(ref TextObject __result, PerkObject perk, bool getSecondary)
+            {
+                TextObject textObject = null;
+                var rolesText = new List<TextObject>();
+                textObject = GameTexts.FindText("str_perk_one_role", null);
+                if (!getSecondary && perk.PrimaryRole != SkillEffect.PerkRole.None)
+                {
+                    rolesText.Add(GameTexts.FindText("role", perk.PrimaryRole.ToString()));
+                    if (RegisterPerkPatch.PerksAdditionalPrimaryRoles.ContainsKey(perk.StringId))
+                    {
+                        rolesText.AddRange(RegisterPerkPatch.PerksAdditionalPrimaryRoles[perk.StringId].Select(d => GameTexts.FindText("role", d.ToString())));
+                    }
+                    textObject.SetTextVariable("PRIMARY_ROLE", NormalizeAdditionalRoles(perk.PrimaryRole, string.Join(" - ", rolesText)));
+                }
+                else if (getSecondary && perk.SecondaryRole != SkillEffect.PerkRole.None)
+                {
+                    rolesText.Add(GameTexts.FindText("role", perk.SecondaryRole.ToString()));
+                    if (RegisterPerkPatch.PerksAdditionalSecondaryRoles.ContainsKey(perk.StringId))
+                    {
+                        rolesText.AddRange(RegisterPerkPatch.PerksAdditionalSecondaryRoles[perk.StringId].Select(d => GameTexts.FindText("role", d.ToString())));
+                    }
+                    textObject.SetTextVariable("PRIMARY_ROLE", NormalizeAdditionalRoles(perk.SecondaryRole, string.Join(" - ", rolesText)));
+
+                }
+
+                __result = textObject;
+            }
+            static string NormalizeAdditionalRoles(SkillEffect.PerkRole perkRole, string text)
+            {
+
+                if (perkRole == SkillEffect.PerkRole.Governor)
+                {
+                    var partyOwner = GameTexts.FindText("role", SkillEffect.PerkRole.PartyOwner.ToString()).ToString();
+                    var partyMember = GameTexts.FindText("role", SkillEffect.PerkRole.PartyMember.ToString()).ToString();
+                    text = text.Replace(partyOwner, "Town/Castle Owner");
+                    text = text.Replace(partyMember, "Town/Castle Member");
+                }
+                if (perkRole == SkillEffect.PerkRole.Personal|| perkRole == SkillEffect.PerkRole.ClanLeader)
+                {
+                    var familyMember = GameTexts.FindText("role", SkillEffect.PerkRole.Captain.ToString()).ToString();
+                    var clanMember = GameTexts.FindText("role", SkillEffect.PerkRole.PartyMember.ToString()).ToString();
+                    text = text.Replace(familyMember, "Family Member");
+                    text = text.Replace(clanMember, "Clan Member");
+                }
+                return text;
+            }
+        }
+        [HarmonyPatch(typeof(DefaultPerks), "RegisterAll")]
+        class RegisterPerkPatch
+        {
+            public static MBReadOnlyList<PerkObject> AllPerks => Game.Current.ObjectManager.GetObjectTypeList<PerkObject>();
+            public static Dictionary<string, List<SkillEffect.PerkRole>> PerksAdditionalPrimaryRoles { get; set; } = new Dictionary<string, List<SkillEffect.PerkRole>>();
+            public static Dictionary<string, List<SkillEffect.PerkRole>> PerksAdditionalSecondaryRoles { get; set; } = new Dictionary<string, List<SkillEffect.PerkRole>>();
+            static void Postfix()
+            {
+
+                if (BannerKingsSettings.Instance.EnableUsefulPerks)
+                {
+                    if (BannerKingsSettings.Instance.EnableUsefulStewardPerks)
+                    {
+                        #region Steward
+                        #region StewardFrugal (done)
+                        ChangePerkRequirement("StewardFrugal", 1);
+                        ChangePerk("StewardFrugal", false, -0.01f,
+                            "Reduce party wages by {VALUE}% for every 20 levels of steward skill if hero is the party quartermaster,\nReduce party wages by {VALUE}% for every 100 levels of steward skill if hero is a party member. (max -30%)",
+                            "Reduce party wages by {VALUE}% for every 20 levels of steward skill if hero is the party quartermaster. (max -40%)"
+                            , SkillEffect.PerkRole.PartyMember);
+
+                        ChangePerk("StewardFrugal", true, -0.01f,
+                            "Reduce recruitment costs by {VALUE}% for every 20 levels of steward skill if hero is the party leader,\nReduce recruitment costs by {VALUE}% for every 100 levels of steward skill if hero is a party member. (max -40%)",
+                            "Reduce recruitment costs by {VALUE}% for every 20 levels of steward skill if hero is the party party leader. (max -40%)",
+                            SkillEffect.PerkRole.PartyMember);
+                        #endregion
+                        #region StewardWarriorsDiet (done)    
+
+                        ChangePerk("StewardWarriorsDiet", false, -0.01f,
+                           "Reduce party food consumption by {VALUE}% for every 15 levels of steward skill if hero is the party quartermaster,\nReduce party food consumption by {VALUE}% for every 100 levels of steward skill if hero is a party member. (max -30%)",
+                           "Reduce party food consumption by {VALUE}% for every 15 levels of steward skill if hero is the party quartermaster. (max -30%)",
+                           SkillEffect.PerkRole.PartyMember);
+
+
+                        #endregion
+                        #region StewardDrillSergant (done)
+                        ChangePerkRequirement("StewardDrillSergant", 2);
+                        ChangePerk("StewardDrillSergant", false, 1f,
+                            "{VALUE} daily experience to troops in your party for every 25 levels of steward skill if hero is the party quartermaster or party leader,\n{VALUE} daily experience to troops in your party for every 100 levels of steward skill if hero is a party member. (max +30)",
+                            "{VALUE} daily experience to troops in your party for every 25 levels of steward skill if hero is the party quartermaster or party leader. (max +30)"
+                            , SkillEffect.PerkRole.PartyLeader, SkillEffect.PerkRole.PartyMember);
+
+
+                        ChangePerk("StewardDrillSergant", true, -0.01f,
+                            "{VALUE}% garrison wages in the town/castle for every 20 levels of steward skill if the hero is the town/castle governer,\n{VALUE}% garrison wages in the town/castle for every 40 levels of steward skill if the hero is a town owner, \n{VALUE}% garrison wages in the town/castle for every 100 levels of steward skill if the hero is staying in town that belongs to his clan.(max -30%)",
+                            "{VALUE}% garrison wages in the town/castle for every 20 levels of steward skill if the hero is the town/castle governer,\n{VALUE}% garrison wages in the town/castle for every 40 levels of steward skill if the hero is a town owner.(max -30%)"
+                            , SkillEffect.PerkRole.PartyOwner, SkillEffect.PerkRole.PartyMember);
+
+                        #endregion
+                        #region StewardSevenVeterans (done)
+                        //this._stewardSevenVeterans.Initialize("{=2ryLuN2i}Seven Veterans", DefaultSkills.Steward, this.GetTierCost(2), this._stewardDrillSergant, "{=gX0edfpK}{VALUE} daily experience for tier 4+ troops in your party.", SkillEffect.PerkRole.Quartermaster, 4f, SkillEffect.EffectIncrementType.Add, "{=g9gTYB8u}{VALUE} militia recruitment in the governed settlement.", SkillEffect.PerkRole.Governor, 1f, SkillEffect.EffectIncrementType.Add, TroopUsageFlags.Undefined, TroopUsageFlags.Undefined);
+                        ChangePerk("StewardSevenVeterans", false, 2f,
+                            "{VALUE} daily experience to tier 4+ troops in your party for every 25 levels of steward skill if hero is the party quartermaster or party leader,\n{VALUE} daily experience to tier 4+ troops in your party for every 100 levels of steward skill if hero is a party member. (max +60)",
+                            "{VALUE} daily experience to tier 4+ troops in your party for every 25 levels of steward skill if hero is the party quartermaster or party leader. (max +30)"
+                            , SkillEffect.PerkRole.PartyLeader, SkillEffect.PerkRole.PartyMember);
+
+                        ChangePerk("StewardSevenVeterans", true, 1f,
+                            "{VALUE} militia recruitment in the town/castle for every 50 levels of steward skill if the hero is the town/castle governer,\n{VALUE} militia recruitment in the town/castle for every 100 levels of steward skill if the hero is a town owner, \n{VALUE} militia recruitment in the town/castle for every 150 levels of steward skill if the hero is staying in town that belongs to his clan.(max +10)",
+                            "{VALUE} militia recruitment in the town/castle for every 50 levels of steward skill if the hero is the town/castle governer,\n{VALUE} militia recruitment in the town/castle for every 100 levels of steward skill if the hero is a town owner.(max +10)"
+                             , SkillEffect.PerkRole.PartyOwner, SkillEffect.PerkRole.PartyMember);
+
+                        #endregion
+                        #region StewardStiffUpperLip (not tested)
+                        //this._stewardStiffUpperLip.Initialize("{=QUeJ4gc3}Stiff Upper Lip", DefaultSkills.Steward, this.GetTierCost(3), this._stewardSweatshops, "{=y9AsEMnV}{VALUE}% food consumption in your party while it is part of an army.", SkillEffect.PerkRole.Quartermaster, -0.1f, SkillEffect.EffectIncrementType.AddFactor, "{=1FPpHasQ}{VALUE}% garrison wages in the governed castle.", SkillEffect.PerkRole.Governor, -0.2f, SkillEffect.EffectIncrementType.AddFactor, TroopUsageFlags.Undefined, TroopUsageFlags.Undefined);          
+                        ChangePerk("StewardStiffUpperLip", false, -0.01f,
+                           "Reduce party food consumption while it is part of an army by {VALUE}% for every 15 levels of steward skill if hero is the party quartermaster,\nReduce party food consumption while it is part of an army by {VALUE}% for every 100 levels of steward skill if hero is a party member. (max -30%)",
+                           "Reduce party food consumption while it is part of an army by {VALUE}% for every 15 levels of steward skill if hero is the party quartermaster. (max -30%)",
+                           SkillEffect.PerkRole.PartyMember);
+
+                        ChangePerk("StewardStiffUpperLip", true, -0.01f,
+                            "{VALUE}% garrison wages in the castle for every 20 levels of steward skill if the hero is the castle governer,\n{VALUE}% garrison wages in the castle for every 40 levels of steward skill if the hero is a castle owner, \n{VALUE}% garrison wages in the castle for every 100 levels of steward skill if the hero is staying in castle that belongs to his clan.(max -30%)",
+                            "{VALUE}% garrison wages in the castle for every 20 levels of steward skill if the hero is the castle governer,\n{VALUE}% garrison wages in the castle for every 40 levels of steward skill if the hero is a castle owner.(max -30%)"
+                            , SkillEffect.PerkRole.PartyOwner, SkillEffect.PerkRole.PartyMember);
+
+                        #endregion
+                        #region StewardSweatshops (not tested)
+                        //this._stewardSweatshops.Initialize("{=jbAtOsIy}Sweatshops", DefaultSkills.Steward, this.GetTierCost(3), this._stewardStiffUpperLip, "{=6wqJA77K}{VALUE}% production rate to owned workshops.", SkillEffect.PerkRole.Personal, 0.2f, SkillEffect.EffectIncrementType.AddFactor, "{=rA9nzrAr}{VALUE}% siege engine build rate in your party.", SkillEffect.PerkRole.Quartermaster, 0.2f, SkillEffect.EffectIncrementType.AddFactor, TroopUsageFlags.Undefined, TroopUsageFlags.Undefined);
+                        ChangePerk("StewardSweatshops", false, 0.01f,
+                          "{VALUE}% production rate to owned workshops for every 10 levels of steward skill,\n{VALUE}% production rate to owned workshops for every 40 levels of steward skill if the hero is family member,\n{VALUE}% production rate to owned workshops for every 100 levels of steward skill if the hero is clan member. (max +100%)",
+                          "{VALUE}% production rate to owned workshops for every 10 levels of steward skill. (max +100%)",
+                          SkillEffect.PerkRole.Captain, SkillEffect.PerkRole.PartyMember);
+
+                        ChangePerk("StewardSweatshops", true, 0.01f,
+                           "{VALUE}% siege engine build rate in your party for every 10 levels of steward skill if hero is the party quartermaster,\n{VALUE}% siege engine build rate in your party for every 100 levels of steward skill if hero is a party member. (max +50%)",
+                           "{VALUE}% siege engine build rate in your party for every 10 levels of steward skill if hero is the party quartermaster. (max +50%)",
+                           SkillEffect.PerkRole.PartyMember);
+
+                        #endregion
+                        #region StewardPaidInPromise (not tested)
+                        //this._stewardPaidInPromise.Initialize("{=CPxbG7Zp}Paid in Promise", DefaultSkills.Steward, this.GetTierCost(4), this._stewardEfficientCampaigner, "{=H9tQfeBr}{VALUE}% companion wages and recruitment fees.", SkillEffect.PerkRole.PartyLeader, -0.25f, SkillEffect.EffectIncrementType.AddFactor, "{=1eKRHLur}Discarded armors are donated to troops for increased experience.", SkillEffect.PerkRole.Quartermaster, 0f, SkillEffect.EffectIncrementType.AddFactor, TroopUsageFlags.Undefined, TroopUsageFlags.Undefined);
+                        ChangePerkRole("StewardPaidInPromise", SkillEffect.PerkRole.ClanLeader);
+                        ChangePerk("StewardPaidInPromise", false, -0.01f,
+                        "Reduce all clan companions wages and recruitment fees by {VALUE}% for every 20 levels of steward skill if the hero is a clan leader,\nReduce all clan companions wages and recruitment fees by {VALUE}% for every 100 levels of steward skill if the hero is a family member.,\nReduce the companion wages by {VALUE}% for every 30 levels of steward skill if the hero is a companion. (max -40%)",
+                        "Reduce all clan companions wages and recruitment fees by {VALUE}% for every 20 levels of steward skill if the hero is a clan leader. (max -40%)"
+                        , SkillEffect.PerkRole.Captain, SkillEffect.PerkRole.Personal);
+                        #endregion
+                        #region StewardEfficientCampaigner (not tested)
+                        //this._stewardEfficientCampaigner.Initialize("{=sC53NYcA}Efficient Campaigner", DefaultSkills.Steward, this.GetTierCost(4), this._stewardPaidInPromise, "{=5t6cveXT}{VALUE} extra food for each food taken during village raids for your party.", SkillEffect.PerkRole.PartyLeader, 1f, SkillEffect.EffectIncrementType.Add, "{=JhFCoWbE}{VALUE}% troop wages in your party while it is part of an army.", SkillEffect.PerkRole.Quartermaster, -0.25f, SkillEffect.EffectIncrementType.AddFactor, TroopUsageFlags.Undefined, TroopUsageFlags.Undefined);
+                        //ChangePerk("StewardEfficientCampaigner", false, 1f,
+                        // "{VALUE} extra food for each food taken during village raids for every 50 levels of steward skill if the hero is party leader,\n{VALUE} extra food taken during village raids for every 150 levels of steward skill if the hero is party member. (max 10)",
+                        // "{VALUE} extra food for each food taken during village raids for every 50 levels of steward skill. (max 10)",
+                        //  SkillEffect.PerkRole.PartyMember);
+
+                        ChangePerk("StewardEfficientCampaigner", true, -0.02f,
+                         "While the party is part of an army reduce its wages by {VALUE}% for every 30 levels of steward skill if hero is the party quartermaster,\nWhile the party is part of an army reduce its wages by by {VALUE}% for every 100 levels of steward skill if hero is a party member. (max -40%)",
+                         "while the party is part of an army reduce its wages by {VALUE}% for every 30 levels of steward skill if hero is the party quartermaster. (max -40%)"
+                         , SkillEffect.PerkRole.PartyMember);
+
+                        #endregion
+                        #region
+                        //this._stewardGivingHands.Initialize("{=VsqyzWYY}Giving Hands", DefaultSkills.Steward, this.GetTierCost(5), this._stewardLogistician, "{=WaGKvsfc}Discarded weapons are donated to troops for increased experience.", SkillEffect.PerkRole.Quartermaster, 0f, SkillEffect.EffectIncrementType.AddFactor, "{=Eo958e7R}{VALUE}% tariff income in the governed settlement.", SkillEffect.PerkRole.Governor, 0.1f, SkillEffect.EffectIncrementType.AddFactor, TroopUsageFlags.Undefined, TroopUsageFlags.Undefined);
+                        #endregion
+                        #region
+                        //this._stewardLogistician.Initialize("{=U2buPiec}Logistician", DefaultSkills.Steward, this.GetTierCost(5), this._stewardGivingHands, "{=sG9WGOeN}{VALUE} party morale when number of mounts is greater than number of foot troops in your party.", SkillEffect.PerkRole.Quartermaster, 4f, SkillEffect.EffectIncrementType.Add, "{=Z1n0w5Kc}{VALUE}% tax income.", SkillEffect.PerkRole.Governor, 0.1f, SkillEffect.EffectIncrementType.AddFactor, TroopUsageFlags.Undefined, TroopUsageFlags.Undefined);
+                        #endregion
+                        #region
+                        //this._stewardRelocation.Initialize("{=R6dnhblo}Relocation", DefaultSkills.Steward, this.GetTierCost(6), this._stewardAidCorps, "{=urSSNtUD}{VALUE}% influence gain from donating troops.", SkillEffect.PerkRole.Quartermaster, 0.25f, SkillEffect.EffectIncrementType.AddFactor, "{=XmqJb7RN}{VALUE}% effect from boosting projects in the governed settlement.", SkillEffect.PerkRole.Governor, 0.2f, SkillEffect.EffectIncrementType.AddFactor, TroopUsageFlags.Undefined, TroopUsageFlags.Undefined);
+                        #endregion
+                        #region
+                        //this._stewardAidCorps.Initialize("{=4FdtVyj1}Aid Corps", DefaultSkills.Steward, this.GetTierCost(6), this._stewardRelocation, "{=ZLbCqt23}Wounded troops in your party are no longer paid wages.", SkillEffect.PerkRole.Quartermaster, 0f, SkillEffect.EffectIncrementType.AddFactor, "{=ULY7byYc}{VALUE}% hearth growth in villages bound to the governed settlement.", SkillEffect.PerkRole.Governor, 0.2f, SkillEffect.EffectIncrementType.AddFactor, TroopUsageFlags.Undefined, TroopUsageFlags.Undefined);
+                        #endregion
+                        #region
+                        //this._stewardGourmet.Initialize("{=63lHFDSG}Gourmet", DefaultSkills.Steward, this.GetTierCost(7), this._stewardSoundReserves, "{=KDtcsKUs}Double the morale bonus from having diverse food in your party.", SkillEffect.PerkRole.Quartermaster, 2f, SkillEffect.EffectIncrementType.AddFactor, "{=q2ZDAm2v}{VALUE}% garrison food consumption during sieges in the governed settlement.", SkillEffect.PerkRole.Governor, -0.1f, SkillEffect.EffectIncrementType.AddFactor, TroopUsageFlags.Undefined, TroopUsageFlags.Undefined);
+                        #endregion
+                        #region
+                        //this._stewardSoundReserves.Initialize("{=O5dgeoss}Sound Reserves", DefaultSkills.Steward, this.GetTierCost(7), this._stewardGourmet, "{=RkYL5eaP}{VALUE}% troop upgrade costs.", SkillEffect.PerkRole.Quartermaster, -0.1f, SkillEffect.EffectIncrementType.AddFactor, "{=P10E5o9l}{VALUE}% food consumption during sieges in your party.", SkillEffect.PerkRole.Quartermaster, -0.1f, SkillEffect.EffectIncrementType.AddFactor, TroopUsageFlags.Undefined, TroopUsageFlags.Undefined);
+                        #endregion
+                        #region
+                        //this._stewardForcedLabor.Initialize("{=cWyqiNrf}Forced Labor", DefaultSkills.Steward, this.GetTierCost(8), this._stewardContractors, "{=HrOTTjgo}Prisoners in your party provide carry capacity as if they are standard troops.", SkillEffect.PerkRole.Quartermaster, 0f, SkillEffect.EffectIncrementType.AddFactor, "{=T9Viygs8}{VALUE}% construction speed per every 3 prisoners.", SkillEffect.PerkRole.Governor, 0.01f, SkillEffect.EffectIncrementType.AddFactor, TroopUsageFlags.Undefined, TroopUsageFlags.Undefined);
+                        #endregion
+                        #region
+                        //this._stewardContractors.Initialize("{=Pg5enC8c}Contractors", DefaultSkills.Steward, this.GetTierCost(8), this._stewardForcedLabor, "{=4220dQ4j}{VALUE}% wages and upgrade costs of the mercenary troops in your party.", SkillEffect.PerkRole.Quartermaster, -0.25f, SkillEffect.EffectIncrementType.AddFactor, "{=xiTD2qUv}{VALUE}% town project effects in the governed settlement.", SkillEffect.PerkRole.Governor, 0.1f, SkillEffect.EffectIncrementType.AddFactor, TroopUsageFlags.Undefined, TroopUsageFlags.Undefined);
+                        #endregion
+                        #region
+                        //this._stewardArenicosMules.Initialize("{=qBx8UbUt}Arenicos' Mules", DefaultSkills.Steward, this.GetTierCost(9), this._stewardArenicosHorses, "{=Yp4zv2ib}{VALUE}% carrying capacity for pack animals in your party.", SkillEffect.PerkRole.Quartermaster, 0.2f, SkillEffect.EffectIncrementType.AddFactor, "{=fswrp38u}{VALUE}% trade penalty for trading pack animals.", SkillEffect.PerkRole.Quartermaster, -0.2f, SkillEffect.EffectIncrementType.AddFactor, TroopUsageFlags.Undefined, TroopUsageFlags.Undefined);
+                        #endregion
+                        #region
+                        //this._stewardArenicosHorses.Initialize("{=tbQ5bUzD}Arenicos' Horses", DefaultSkills.Steward, this.GetTierCost(9), this._stewardArenicosMules, "{=G9OTNRs4}{VALUE}% carrying capacity for troops in your party.", SkillEffect.PerkRole.Quartermaster, 0.1f, SkillEffect.EffectIncrementType.AddFactor, "{=xm4eEbQY}{VALUE}% trade penalty for trading mounts.", SkillEffect.PerkRole.Personal, -0.2f, SkillEffect.EffectIncrementType.AddFactor, TroopUsageFlags.Undefined, TroopUsageFlags.Undefined);
+                        #endregion
+                        #region
+                        //this._stewardMasterOfPlanning.Initialize("{=n5aT1Y7s}Master of Planning", DefaultSkills.Steward, this.GetTierCost(10), this._stewardMasterOfWarcraft, "{=KMmAG5bk}{VALUE}% food consumption while your party is in a siege camp.", SkillEffect.PerkRole.Quartermaster, -0.4f, SkillEffect.EffectIncrementType.AddFactor, "{=P5OjioRl}{VALUE}% effectiveness to continuous projects in the governed settlement. ", SkillEffect.PerkRole.Governor, 0.2f, SkillEffect.EffectIncrementType.AddFactor, TroopUsageFlags.Undefined, TroopUsageFlags.Undefined);
+                        #endregion
+                        #region
+                        //this._stewardMasterOfWarcraft.Initialize("{=MM0ARhGh}Master of Warcraft", DefaultSkills.Steward, this.GetTierCost(10), this._stewardMasterOfPlanning, "{=StzVsQ2P}{VALUE}% troop wages while your party is in a siege camp.", SkillEffect.PerkRole.Quartermaster, -0.25f, SkillEffect.EffectIncrementType.AddFactor, "{=ya7alenH}{VALUE}% food consumption of town population in the governed settlement.", SkillEffect.PerkRole.Governor, -0.05f, SkillEffect.EffectIncrementType.AddFactor, TroopUsageFlags.Undefined, TroopUsageFlags.Undefined);
+                        #endregion
+                        #region
+                        //this._stewardPriceOfLoyalty.Initialize("{=eVTnUmSB}Price of Loyalty", DefaultSkills.Steward, this.GetTierCost(11), null, "{=sYrG8rNy}{VALUE}% to food consumption, wages and combat related morale loss for each steward point above 250 in your party.", SkillEffect.PerkRole.Quartermaster, -0.005f, SkillEffect.EffectIncrementType.AddFactor, "{=lwp50FuF}{VALUE}% tax income for each skill point above 200 in the governed settlement", SkillEffect.PerkRole.Governor, 0.005f, SkillEffect.EffectIncrementType.AddFactor, TroopUsageFlags.Undefined, TroopUsageFlags.Undefined);
+                        #endregion
+                        #endregion
+
+                    }
+
+                }
+
+            }
+            private static readonly int[] Requirements =
+            {
+                 20,
+                 40,
+                 60,
+                 80,
+                 100,
+                 120,
+                 140,
+                 160,
+                 180,
+                 200,
+                 220,
+                 260,
+                 280,
+                 300,
+                 320,
+             };
+            public static int GetTierCost(int tierIndex)
+            {
+                return Requirements[tierIndex - 1];
+            }
+            private static void ChangePerkRequirement(string perkId, int tierIndex)
+            {
+                var perk = AllPerks.FirstOrDefault(d => d.StringId == perkId);
+                if (perk != null)
+                {
+
+                    perk.SetPrivatePropertyValue("RequiredSkillValue", (float)BKPerks.GetTierCost(tierIndex));
+                    perk.AlternativePerk?.SetPrivatePropertyValue("RequiredSkillValue", (float)BKPerks.GetTierCost(tierIndex));
+                }
+            }
+            private static void ChangePerkRole(string perkId, SkillEffect.PerkRole newRole , bool isSecondary=false)
+            {
+                var perk = AllPerks.FirstOrDefault(d => d.StringId == perkId);
+                if (perk != null)
+                {
+                    if (isSecondary)
+                    {
+                        perk.SetPrivatePropertyValue("SecondaryRole", newRole);
+                    }
+                    else
+                    {
+                        perk.SetPrivatePropertyValue("PrimaryRole", newRole);
+                    }
+                   
+                    
+                }
+            }
+            private static void ChangePerk(string perkId, bool isSecondary, float bonus, string description1, string description2, params SkillEffect.PerkRole[] additionalSecondaryRoles)
+            {
+                var perk = AllPerks.FirstOrDefault(d => d.StringId == perkId);
+                if (perk != null)
+                {
+                    if (BannerKingsSettings.Instance.EnableUsefulPerksFromAllPartyMembers)
+                    {
+                        if (isSecondary)
+                        {
+                            perk.SetPrivatePropertyValue("SecondaryBonus", bonus);
+                            perk.SetPrivatePropertyValue("SecondaryDescription", new TextObject(description1, null));
+                            PerkHelper.SetDescriptionTextVariable(perk.SecondaryDescription, perk.SecondaryBonus, perk.SecondaryIncrementType);
+                            PerksAdditionalSecondaryRoles.Add(perkId, additionalSecondaryRoles.ToList());
+                        }
+                        else
+                        {
+                            perk.SetPrivatePropertyValue("PrimaryBonus", bonus);
+                            perk.SetPrivatePropertyValue("PrimaryDescription", new TextObject(description1, null));
+                            PerkHelper.SetDescriptionTextVariable(perk.PrimaryDescription, perk.PrimaryBonus, perk.PrimaryIncrementType);
+                            PerksAdditionalPrimaryRoles.Add(perkId, additionalSecondaryRoles.ToList());
+                        }
+
+                    }
+                    else
+                    {
+                        if (isSecondary)
+                        {
+
+                            perk.SetPrivatePropertyValue("SecondaryBonus", bonus);
+                            perk.SetPrivatePropertyValue("SecondaryDescription", new TextObject(description2, null));
+                            PerkHelper.SetDescriptionTextVariable(perk.SecondaryDescription, perk.SecondaryBonus, perk.SecondaryIncrementType);
+                            PerksAdditionalSecondaryRoles.Add(perkId, additionalSecondaryRoles.ToList());
+                        }
+                        else
+                        {
+                            perk.SetPrivatePropertyValue("PrimaryBonus", bonus);
+                            perk.SetPrivatePropertyValue("PrimaryDescription", new TextObject(description2, null));
+                            PerkHelper.SetDescriptionTextVariable(perk.PrimaryDescription, perk.PrimaryBonus, perk.PrimaryIncrementType);
+                            PerksAdditionalPrimaryRoles.Add(perkId, additionalSecondaryRoles.ToList());
+                        }
+
+                    }
+                }
+            }
+        }
+    }
+}

--- a/BannerKings/Settings/BannerKingsSettings.cs
+++ b/BannerKings/Settings/BannerKingsSettings.cs
@@ -149,5 +149,27 @@ namespace BannerKings.Settings
             HintText = "{=gDK2LRib}Maximum number of bandit parties in the world map. Vanilla is 150. Default: 150.")]
         [SettingPropertyGroup("{=k2Vw7iNm}Bandits")]
         public int BanditPartiesLimit { get; set; } = 150;
+
+
+
+
+        [SettingPropertyBool("Enable Useful Perks", Order =0,  HintText = "Enable perks to scale up with skill level Default: True.")]
+        [SettingPropertyGroup("Useful Perks")]
+        public bool EnableUsefulPerks { get; set; } = true;
+
+
+        [SettingPropertyBool("Enable Perks From All Party Members", Order = 1, HintText = "Enable perks to become effective from all party members with a reduced ratio. Default setting is True.")]
+        [SettingPropertyGroup("Useful Perks")]
+        public bool EnableUsefulPerksFromAllPartyMembers { get; set; } = true;
+
+        [SettingPropertyBool("Enable Governor Perks From Settlement Owner", Order = 2, HintText = "Enable governor perks to become effective from settlement owners with a reduced ratio. Default setting is True.")]
+        [SettingPropertyGroup("Useful Perks")]
+        public bool EnableUsefulGovernorPerksFromSettlementOwner { get; set; } = true;
+
+
+        [SettingPropertyBool("Enable Useful Steward Perks", Order = 3, HintText = "Enable perks to scale up with skill level Default: True.")]
+        [SettingPropertyGroup("Useful Perks")]
+        public bool EnableUsefulStewardPerks { get; set; } = true;
+
     }
 }

--- a/BannerKings/Utils/PrivateValueManipulator.cs
+++ b/BannerKings/Utils/PrivateValueManipulator.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Reflection;
+
+namespace BannerKings.Utils
+{
+    public static class PrivateValueManipulator
+    {
+        /// <summary>
+        /// Returns a _private_ Property Value from a given Object. Uses Reflection.
+        /// Throws a ArgumentOutOfRangeException if the Property is not found.
+        /// </summary>
+        /// <typeparam name="T">Type of the Property</typeparam>
+        /// <param name="obj">Object from where the Property Value is returned</param>
+        /// <param name="propName">Propertyname as string.</param>
+        /// <returns>PropertyValue</returns>
+        public static T GetPrivatePropertyValue<T>(this object obj, string propName)
+        {
+            if (obj == null) throw new ArgumentNullException("obj");
+            PropertyInfo pi = obj.GetType().GetProperty(propName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (pi == null) throw new ArgumentOutOfRangeException("propName", string.Format("Property {0} was not found in Type {1}", propName, obj.GetType().FullName));
+            return (T)pi.GetValue(obj, null);
+        }
+
+        /// <summary>
+        /// Returns a private Property Value from a given Object. Uses Reflection.
+        /// Throws a ArgumentOutOfRangeException if the Property is not found.
+        /// </summary>
+        /// <typeparam name="T">Type of the Property</typeparam>
+        /// <param name="obj">Object from where the Property Value is returned</param>
+        /// <param name="propName">Propertyname as string.</param>
+        /// <returns>PropertyValue</returns>
+        public static T GetPrivateFieldValue<T>(this object obj, string propName)
+        {
+            if (obj == null) throw new ArgumentNullException("obj");
+            Type t = obj.GetType();
+            FieldInfo fi = null;
+            while (fi == null && t != null)
+            {
+                fi = t.GetField(propName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                t = t.BaseType;
+            }
+            if (fi == null) throw new ArgumentOutOfRangeException("propName", string.Format("Field {0} was not found in Type {1}", propName, obj.GetType().FullName));
+            return (T)fi.GetValue(obj);
+        }
+
+        /// <summary>
+        /// Sets a _private_ Property Value from a given Object. Uses Reflection.
+        /// Throws a ArgumentOutOfRangeException if the Property is not found.
+        /// </summary>
+        /// <typeparam name="T">Type of the Property</typeparam>
+        /// <param name="obj">Object from where the Property Value is set</param>
+        /// <param name="propName">Propertyname as string.</param>
+        /// <param name="val">Value to set.</param>
+        /// <returns>PropertyValue</returns>
+        public static void SetPrivatePropertyValue<T>(this object obj, string propName, T val)
+        {
+            Type t = obj.GetType();
+            if (t.GetProperty(propName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance) == null)
+                throw new ArgumentOutOfRangeException("propName", string.Format("Property {0} was not found in Type {1}", propName, obj.GetType().FullName));
+            t.InvokeMember(propName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.SetProperty | BindingFlags.Instance, null, obj, new object[] { val });
+        }
+
+        /// <summary>
+        /// Set a private Property Value on a given Object. Uses Reflection.
+        /// </summary>
+        /// <typeparam name="T">Type of the Property</typeparam>
+        /// <param name="obj">Object from where the Property Value is returned</param>
+        /// <param name="propName">Propertyname as string.</param>
+        /// <param name="val">the value to set</param>
+        /// <exception cref="ArgumentOutOfRangeException">if the Property is not found</exception>
+        public static void SetPrivateFieldValue<T>(this object obj, string propName, T val)
+        {
+            if (obj == null) throw new ArgumentNullException("obj");
+            Type t = obj.GetType();
+            FieldInfo fi = null;
+            while (fi == null && t != null)
+            {
+                fi = t.GetField(propName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                t = t.BaseType;
+            }
+            if (fi == null) throw new ArgumentOutOfRangeException("propName", string.Format("Field {0} was not found in Type {1}", propName, obj.GetType().FullName));
+            fi.SetValue(obj, val);
+        }
+    }
+}


### PR DESCRIPTION
Improve the impact of perks when the feature is turned on from the settings, enabling perks to increase in power as related character skill level improves. Also, expand the range of roles for each skill to offer more flexibility.

Example: 
![image](https://github.com/R-Vaccari/bannerlord-banner-kings/assets/20624652/7de89388-ca9f-438c-a3b9-0f50cf739ca5)

OneHanded Progress => Perks (0/21) 
TwoHanded Progress => Perks (0/18) 
Polearm Progress => Perks (0/21) 
Bow Progress => Perks (0/21) 
Crossbow Progress => Perks (0/21) 
Throwing Progress => Perks (0/21) 
Riding Progress => Perks (0/20) 
Athletics Progress => Perks (0/21) 
Crafting Progress => Perks (0/20) 
Tactics Progress => Perks (0/21) 
Scouting Progress => Perks (0/21) 
Roguery Progress => Perks (0/21)
Charm Progress => Perks (0/20) 
Leadership Progress => Perks (0/21)
Trade Progress => Perks (0/21) 
Steward Progress => Perks (8/21)
Medicine Progress => Perks (0/21)
Engineering Progress => Perks (0/21)
Scholarship Progress => Perks (0/13)
Theology Progress => Perks (0/6)
Lordship Progress => Perks (0/8)

