### PR TITLE
Custom Settlement Types Compatibility Patch

### DIFF
--- a/BannerKings/Behaviours/BKClanBehavior.cs
+++ b/BannerKings/Behaviours/BKClanBehavior.cs
@@ -337,7 +337,7 @@ namespace BannerKings.Behaviours
 
         private void OnSettlementEntered(MobileParty party, Settlement target, Hero hero)
         {
-            if (hero != Hero.MainHero || target.Town == null)
+            if (hero != Hero.MainHero || target.Town == null || Utils.Helpers.IsNonBaseGameSettlement(target))
             {
                 return;
             }

--- a/BannerKings/Behaviours/BKEducationBehavior.cs
+++ b/BannerKings/Behaviours/BKEducationBehavior.cs
@@ -208,6 +208,9 @@ namespace BannerKings.Behaviours
 
         private void InitializeEducation(Hero hero, bool addExtraLanguages = false)
         {
+            if (Utils.Helpers.IsNonBaseGameSettlement(hero.BornSettlement))
+                return;
+
             Dictionary<Language, float> startingLanguages = null;
             if (hero.Clan != null && hero != hero.Clan.Leader && hero.Clan.Leader != null)
             {

--- a/BannerKings/Behaviours/BKGentryBehavior.cs
+++ b/BannerKings/Behaviours/BKGentryBehavior.cs
@@ -169,7 +169,8 @@ namespace BannerKings.Behaviours
             ExceptionUtils.TryCatch(() =>
             {
                 if (party == null || !party.IsLordParty || party.WarPartyComponent == null || party.LeaderHero == null || 
-                party.ActualClan == null || party.ActualClan == Clan.PlayerClan)
+                party.ActualClan == null || party.ActualClan == Clan.PlayerClan || 
+                Utils.Helpers.IsNonBaseGameSettlement(target))
                 {
                     return;
                 }

--- a/BannerKings/Behaviours/BKLifestyleBehavior.cs
+++ b/BannerKings/Behaviours/BKLifestyleBehavior.cs
@@ -28,7 +28,8 @@ namespace BannerKings.Behaviours
 
         private void OnSettlementEntered(MobileParty mobileParty, Settlement settlement, Hero hero)
         {
-            if (mobileParty != null && mobileParty.IsCaravan && mobileParty.Owner != null && settlement.Notables != null)
+            if (mobileParty != null && mobileParty.IsCaravan && mobileParty.Owner != null && settlement.Notables != null
+                && !Utils.Helpers.IsNonBaseGameSettlement(settlement))
             {
                 var education = BannerKingsConfig.Instance.EducationManager.GetHeroEducation(mobileParty.Owner);
                 if (education.HasPerk(BKPerks.Instance.CaravaneerOutsideConnections) && MBRandom.RandomFloat < 0.1f)
@@ -48,7 +49,7 @@ namespace BannerKings.Behaviours
             var education = BannerKingsConfig.Instance.EducationManager.GetHeroEducation(Hero.MainHero);
             if (education.Lifestyle == DefaultLifestyles.Instance.Outlaw && character.IsHero)
             {
-                if (character.Occupation != Occupation.GangLeader ||
+                if (!character.HeroObject.IsGangLeader ||
                     character.HeroObject.GetTraitLevel(DefaultTraits.Honor) >= 0)
                 {
                     var random = MBRandom.RandomFloat;

--- a/BannerKings/Behaviours/BKLordPropertyBehavior.cs
+++ b/BannerKings/Behaviours/BKLordPropertyBehavior.cs
@@ -24,7 +24,7 @@ namespace BannerKings.Behaviours
 
         private void OnSettlementEntered(MobileParty party, Settlement target, Hero hero)
         {
-            if (party?.LeaderHero == null || !party.IsLordParty)
+            if (party?.LeaderHero == null || !party.IsLordParty || Utils.Helpers.IsNonBaseGameSettlement(target))
             {
                 return;
             }

--- a/BannerKings/Behaviours/BKPartyBehavior.cs
+++ b/BannerKings/Behaviours/BKPartyBehavior.cs
@@ -412,7 +412,7 @@ namespace BannerKings.Behaviours
 
         private void OnSettlementEntered(MobileParty party, Settlement target, Hero hero)
         {
-            if (party == null || party == MobileParty.MainParty)
+            if (party == null || party == MobileParty.MainParty || Utils.Helpers.IsNonBaseGameSettlement(target))
             {
                 return;
             }

--- a/BannerKings/Behaviours/BKReligionsBehavior.cs
+++ b/BannerKings/Behaviours/BKReligionsBehavior.cs
@@ -554,7 +554,9 @@ namespace BannerKings.Behaviours
 
         private void OnSettlementEntered(MobileParty party, Settlement target, Hero hero)
         {
-            if (hero != Hero.MainHero || target.Town == null || BannerKingsConfig.Instance.PopulationManager == null || !BannerKingsConfig.Instance.PopulationManager.IsSettlementPopulated(target))
+            if (hero != Hero.MainHero || target.Town == null || BannerKingsConfig.Instance.PopulationManager == null || 
+                !BannerKingsConfig.Instance.PopulationManager.IsSettlementPopulated(target) ||
+                Utils.Helpers.IsNonBaseGameSettlement(target))
             {
                 return;
             }

--- a/BannerKings/Behaviours/Feasts/BKFeastBehavior.cs
+++ b/BannerKings/Behaviours/Feasts/BKFeastBehavior.cs
@@ -1,5 +1,6 @@
 using BannerKings.Behaviours.Marriage;
 using BannerKings.Managers.Goals.Decisions;
+using BannerKings.Utils;
 using System.Collections.Generic;
 using System.Linq;
 using TaleWorlds.CampaignSystem;
@@ -220,7 +221,8 @@ namespace BannerKings.Behaviours.Feasts
 
         private void OnSettlementEntered(MobileParty party, Settlement target, Hero hero)
         {
-            if (hero != Hero.MainHero || target.Town == null || !feasts.ContainsKey(target.Town))
+            if (hero != Hero.MainHero || target.Town == null 
+                || Utils.Helpers.IsNonBaseGameSettlement(target) || !feasts.ContainsKey(target.Town))
             {
                 return;
             }

--- a/BannerKings/Behaviours/PartyNeeds/BKPartyNeedsBehavior.cs
+++ b/BannerKings/Behaviours/PartyNeeds/BKPartyNeedsBehavior.cs
@@ -142,7 +142,8 @@ namespace BannerKings.Behaviours.PartyNeeds
         private void OnSettlementEntered(MobileParty party, Settlement target, Hero hero)
         {
             if (target == null || party == null || hero == null || !party.IsLordParty ||
-                hero == Hero.MainHero || (!target.IsVillage && target.IsFortification))
+                hero == Hero.MainHero || (!target.IsVillage && target.IsFortification) || 
+                Utils.Helpers.IsNonBaseGameSettlement(target))
             {
                 return;
             }

--- a/BannerKings/Managers/AI/AIBehavior.cs
+++ b/BannerKings/Managers/AI/AIBehavior.cs
@@ -215,17 +215,17 @@ namespace BannerKings.Managers.AI
                         {
                             if (hero.IsNotable)
                             {
-                                if (occupation == Occupation.GangLeader)
+                                if (hero.IsGangLeader)
                                 {
                                     rogueWeight += 2;
                                 }
 
-                                if (occupation == Occupation.Artisan)
+                                if (hero.IsArtisan)
                                 {
                                     artisanWeight += 2;
                                 }
 
-                                if (occupation == Occupation.Merchant)
+                                if (hero.IsMerchant)
                                 {
                                     merchantWeight += 2;
                                 }

--- a/BannerKings/Models/Vanilla/BKEconomyModel.cs
+++ b/BannerKings/Models/Vanilla/BKEconomyModel.cs
@@ -385,10 +385,9 @@ namespace BannerKings.Models.Vanilla
 
         public override int GetNotableCaravanLimit(Hero notable)
         {
-            Occupation occupation = notable.Occupation;
-            if (occupation == Occupation.Merchant) return 3;
-            else if (occupation == Occupation.Artisan) return 2;
-            else if (occupation == Occupation.GangLeader) return 1;
+            if (notable.IsMerchant) return 3;
+            else if (notable.IsArtisan) return 2;
+            else if (notable.IsGangLeader) return 1;
 
             return 0;
         }

--- a/BannerKings/Patches/FixesPatches.cs
+++ b/BannerKings/Patches/FixesPatches.cs
@@ -35,6 +35,9 @@ namespace BannerKings.Patches
             private static bool GetGarrisonLeaveOrTakeDataOfPartyPrefix(MobileParty mobileParty, ref ValueTuple<int, int> __result)
             {
                 Settlement currentSettlement = mobileParty.CurrentSettlement;
+                if (Utils.Helpers.IsNonBaseGameSettlement(currentSettlement))
+                    return true;
+
                 int num = TaleWorlds.CampaignSystem.Campaign.Current.Models.SettlementGarrisonModel
                     .FindNumberOfTroopsToLeaveToGarrison(mobileParty, currentSettlement);
                 int item = 0;
@@ -254,6 +257,9 @@ namespace BannerKings.Patches
             private static bool GetSiegeAftermathInfluenceCostPrefix(MobileParty attackerParty, Settlement settlement, 
                 SiegeAftermathAction.SiegeAftermath aftermathType, ref float __result)
             {
+                if (Utils.Helpers.IsNonBaseGameSettlement(settlement))
+                    return true;
+
                 float result = 0f;
                 if (attackerParty.Army != null && aftermathType != SiegeAftermathAction.SiegeAftermath.Pillage)
                 {
@@ -327,6 +333,9 @@ namespace BannerKings.Patches
             [HarmonyPatch("DailyTickSettlement")]
             private static bool CreateTownOrderPrefix(CraftingCampaignBehavior __instance, Settlement settlement)
             {
+                if (Utils.Helpers.IsNonBaseGameSettlement(settlement))
+                    return true;
+
                 if (settlement.IsTown && __instance.CraftingOrders[settlement.Town].IsThereAvailableSlot())
                 {
                     List<Hero> list = new List<Hero>();

--- a/BannerKings/Patches/FixesPatches.cs
+++ b/BannerKings/Patches/FixesPatches.cs
@@ -74,7 +74,8 @@ namespace BannerKings.Patches
             [HarmonyPatch("ConditionsHold")]
             private static bool ConditionsHoldPrefix(Hero issueGiver, ref Settlement selectedHideout, ref bool __result)
             {
-                if (issueGiver.CurrentSettlement == null || issueGiver.CurrentSettlement.IsVillage)
+                if (issueGiver.CurrentSettlement == null || issueGiver.CurrentSettlement.IsVillage || 
+                    Utils.Helpers.IsNonBaseGameSettlement(issueGiver.CurrentSettlement))
                 {
                     __result = false;
                     return false;

--- a/BannerKings/Patches/NotablePatches.cs
+++ b/BannerKings/Patches/NotablePatches.cs
@@ -23,6 +23,9 @@ namespace BannerKings.Patches
         {
             private static bool Prefix(Occupation neededOccupation, ref Hero __result, Settlement forcedHomeSettlement = null)
             {
+                if (Utils.Helpers.IsNonBaseGameSettlement(forcedHomeSettlement))
+                    return true;
+                
                 Settlement settlement = forcedHomeSettlement ?? SettlementHelper.GetRandomTown(null);
                 var data = BannerKingsConfig.Instance.PopulationManager.GetPopData(settlement);
                 IEnumerable<CharacterObject> enumerable;
@@ -122,6 +125,9 @@ namespace BannerKings.Patches
         {
             private static bool Prefix(Settlement settlement)
             {
+                if (Utils.Helpers.IsNonBaseGameSettlement(settlement))
+                    return true;
+
                 var list = new List<Occupation>();
                 if (settlement.IsTown)
                 {
@@ -203,6 +209,9 @@ namespace BannerKings.Patches
         {
             private static bool Prefix(Settlement settlement)
             {
+                if (Utils.Helpers.IsNonBaseGameSettlement(settlement))
+                    return true;
+
                 if ((settlement.IsTown || settlement.IsCastle) && settlement.Town.Governor != null)
                 {
                     var governor = settlement.Town.Governor;

--- a/BannerKings/Utils/Helpers.cs
+++ b/BannerKings/Utils/Helpers.cs
@@ -351,5 +351,11 @@ namespace BannerKings.Utils
 
             return ConsumptionType.None;
         }
+
+        public static bool IsNonBaseGameSettlement(Settlement s)
+        {
+            return s != null && !s.IsHideout && !s.IsTown && !s.IsVillage && !s.IsCastle 
+                && s.SettlementComponent as RetirementSettlementComponent == null;
+        }
     }
 }


### PR DESCRIPTION
This pull request adds conditionals in the beginning of many Banner Kings functions that involve settlements. This conditional prevents Banner Kings functions from running on settlements that are not one of the base game settlement types (Village, Town, Castle, Hideout or RetirementSettlement). 

My mod defines a custom settlement type called "Minor Faction Hideouts" that can work with this patch. This also allows Banner Kings to be compatible with any other mod that also defines a custom settlement type. 

No original functionality is changed as this only affects custom settlement types and Banner Kings only works with base game settlement types.

[https://www.nexusmods.com/mountandblade2bannerlord/mods/6771/?tab=description&jump_to_comment=138548328](Nexus Mods Link)