### PR TITLE
Fixed a bug that prevent slaves from contributing to Construction speed.

### DIFF
--- a/BannerKings/Managers/Populations/LandData.cs
+++ b/BannerKings/Managers/Populations/LandData.cs
@@ -174,7 +174,14 @@ namespace BannerKings.Managers.Populations
             }
         }
 
-        public int SlavesConstructionForce => Math.Max((int)(data.EconomicData.StateSlaves * 0.5), 0);
+        public int SlavesConstructionForce
+        {
+            get
+            {
+                var slaves = data.GetTypeCount(PopulationManager.PopType.Slaves) * (data.Settlement.IsVillage ? 0.85f : 0.5f) * data.EconomicData.StateSlaves;
+                return Math.Max((int)(slaves * 0.15), 0);
+            }
+        }
 
         public int AvailableWorkForce => AvailableTenantsWorkForce + AvailableSlavesWorkForce + AvailableSerfsWorkForce;
 


### PR DESCRIPTION
`SlavesConstructionForce` is expected to be an integer number that represents number of available men, just like `TenantsConstructionForce` and `SlavesConstructionForce`.
It's always ZERO now since `data.EconomicData.StateSlaves` is a float number between 0 and 1, representing percentage of state slaves. It should be multiplied by the number of slaves in that settlement.