### PR TITLE
Fix for kingdom tab loop locking the player for unresolved decisions they cant' vote in.

### DIFF
--- a/BannerKings/Managers/Kingdoms/Council/BKCouncilPositionDecision.cs
+++ b/BannerKings/Managers/Kingdoms/Council/BKCouncilPositionDecision.cs
@@ -21,7 +21,7 @@ namespace BannerKings.Managers.Kingdoms.Council
             Data = data;
             Position = position;
             Religion = BannerKingsConfig.Instance.ReligionsManager.GetHeroReligion(proposerClan.Leader);
-            IsEnforced = true;
+            IsEnforced = Clan.PlayerClan.Kingdom == proposerClan.Kingdom && !Clan.PlayerClan.IsUnderMercenaryService;
             Suggested = suggested;
         }
 


### PR DESCRIPTION
Changed hardcoded true assignment that locks the player in the kingdom tab for decisions that they can't vote for. New check defines the enforcement based on the player being able to vote (in kingdom and not mercenary)