### PR TITLE
fix: Added missing method and fields to MarketGroup

### DIFF
--- a/BannerKings/CampaignContent/Economy/Markets/MarketGroup.cs
+++ b/BannerKings/CampaignContent/Economy/Markets/MarketGroup.cs
@@ -1,31 +1,44 @@
 ﻿using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
 using TaleWorlds.Localization;
 
 namespace BannerKings.CampaignContent.Economy.Markets
 {
     public class MarketGroup : BannerKingsObject
     {
-        public MarketGroup(string id) : base(id)
-        {
+        public MarketGroup(string id) : base(id) {
         }
 
-        public void Initialize(TextObject name, TextObject description, CultureObject culture, Dictionary<CultureObject, float> spawns)
-        {
+        public void Initialize(TextObject name, TextObject description, CultureObject culture, Dictionary<CultureObject, float> spawns, Dictionary<ItemCategory, float> demands = null) {
             Initialize(name, description);
             Culture = culture;
             Spawns = spawns;
+            Demands = demands;
         }
 
         public CultureObject Culture { get; private set; }
         public Dictionary<CultureObject, float> Spawns { get; private set; }
+        public Dictionary<ItemCategory, float> Demands { get; private set; }
 
-        public float GetSpawn(CultureObject culture)
-        {
+        public float GetSpawn(CultureObject culture) {
             float result = 0f;
             if (culture.StringId == Culture.StringId) result = 1f;
             else if (Spawns.ContainsKey(culture)) result = Spawns[culture];
 
+            return result;
+        }
+
+        public float GetDemand(ItemCategory itemCategory) {
+            bool flag = this.Demands == null;
+            if (flag) {
+                this.Demands = new Dictionary<ItemCategory, float>();
+            }
+            float result;
+            bool flag2 = !this.Demands.TryGetValue(itemCategory, out result);
+            if (flag2) {
+                result = 1f;
+            }
             return result;
         }
     }

--- a/BannerKings/Main.cs
+++ b/BannerKings/Main.cs
@@ -138,7 +138,7 @@ namespace BannerKings
             campaignStarter.AddModel(new BKCategorySelector());
             campaignStarter.AddModel(new BKSettlementAccessModel());
             campaignStarter.AddModel(BannerKingsConfig.Instance.MarriageModel);
-            campaignStarter.AddModel(new BKItemValueModel());
+            //campaignStarter.AddModel(new BKItemValueModel());
             campaignStarter.AddModel(new BKTargetScoreModel());
 
             BKAttributes.Instance.Initialize();


### PR DESCRIPTION
I fixed the compile issue in main `campaignStarter.AddModel(new BKItemValueModel())` was no longer needed.

I decompiled the latest release to fix the issues with `MarketGroup`